### PR TITLE
cogp-rs: add --lod-feature-growth to smooth LoD ramp-up

### DIFF
--- a/cogp-rs/src/convert.rs
+++ b/cogp-rs/src/convert.rs
@@ -86,6 +86,14 @@ pub struct ConvertArgs {
     /// lines still span many cells along their length. Set to `1` to disable.
     #[arg(long, default_value_t = 2)]
     pub line_thinning_factor: u32,
+    /// Optional cap on how fast the per-LoD feature count grows. The natural
+    /// progression is ~4× per LoD (cell-area halves each axis), which can feel
+    /// abrupt when LoD 0 is intentionally sparse. Setting this to `N` (e.g.
+    /// `2.0`) restricts LoD i to at most `N × |LoD i-1|` features; surplus
+    /// cell-winners (lowest-priority first) are deferred to finer LoDs. LoD 0
+    /// is uncapped. When omitted, no cap is applied.
+    #[arg(long)]
+    pub lod_feature_growth: Option<f64>,
 }
 
 #[derive(Clone, Copy, Debug, clap::ValueEnum)]
@@ -197,6 +205,14 @@ pub fn run(args: ConvertArgs) -> Result<()> {
             args.line_thinning_factor
         );
     }
+    if let Some(g) = args.lod_feature_growth {
+        if !(g > 0.0 && g.is_finite()) {
+            bail!(
+                "--lod-feature-growth must be a finite positive number (got {})",
+                g
+            );
+        }
+    }
 
     eprintln!("[1/4] Reading input: {}", args.input.display());
     let file = File::open(&args.input)
@@ -287,6 +303,7 @@ pub fn run(args: ConvertArgs) -> Result<()> {
         input_units,
         args.point_thinning_factor,
         args.line_thinning_factor,
+        args.lod_feature_growth,
     )?;
     let mut per_lod_full: Vec<Vec<u32>> = vec![Vec::new(); gsds.len()];
     for (idx, lod_i) in assignment.iter().enumerate() {
@@ -726,6 +743,7 @@ fn assign_lods(
     units: InputUnits,
     point_thinning_factor: u32,
     line_thinning_factor: u32,
+    lod_feature_growth: Option<f64>,
 ) -> Result<Vec<u16>> {
     // WGS84 equatorial circumference / 360°: meters per degree of longitude at the equator.
     // Used only as a rendering-grade scale factor — see the README note on geodesy.
@@ -774,6 +792,7 @@ fn assign_lods(
         })
         .collect();
 
+    let mut prev_picked: usize = 0;
     for (lod_i, prec) in precs.iter().enumerate() {
         // Per-cell winner map built in parallel: each thread folds into a local
         // HashMap, then reduce merges them keeping the higher-priority row on
@@ -832,7 +851,25 @@ fn assign_lods(
                 }
                 a
             });
-        let picked: Vec<u32> = best.values().copied().collect();
+        let mut picked: Vec<u32> = best.values().copied().collect();
+        // Smooth feature-count growth across LoDs: cap LoD i at
+        // `growth × |LoD i-1|`, deferring the lowest-priority cell winners to
+        // finer LoDs. LoD 0 is uncapped — it sets the baseline.
+        if let Some(growth) = lod_feature_growth {
+            if lod_i > 0 {
+                let cap = ((prev_picked as f64) * growth).ceil() as usize;
+                if picked.len() > cap {
+                    let mut with_pri: Vec<(u32, (u64, u64))> = picked
+                        .par_iter()
+                        .map(|&r| (r, priority(&bboxes[r as usize], r)))
+                        .collect();
+                    with_pri.par_sort_unstable_by(|a, b| b.1.cmp(&a.1));
+                    with_pri.truncate(cap);
+                    picked = with_pri.into_iter().map(|(r, _)| r).collect();
+                }
+            }
+        }
+        prev_picked = picked.len();
         for r in &picked {
             assigned[*r as usize] = lod_i as i32;
         }


### PR DESCRIPTION
## Summary

- LoD ごとの feature 数増加率に上限を設ける `--lod-feature-growth N` を追加。LoD i の picks が `N × |LoD i-1|` を超えた場合、priority 下位のセル勝者を次の LoD に繰り延べる。LoD 0 は上限なし。未指定時は従来の挙動。
- 動機: cell ベースの thinning は構造上 ~4×/LoD で feature が増えるため、`--base-resolution 1024` のように LoD 0 を意図的にスパースにすると LoD 1 で唐突に急増して見える。`--lod-feature-growth 2` のような値で立ち上がりを滑らかにできる。

## Implementation

`assign_lods` のメインループ末尾で、`lod_i > 0` かつ `picked.len() > prev * growth` のとき priority 降順で top-cap だけ残し、それ以外は次 LoD に繰り越し。`prev_picked` を都度更新。

## Test plan

- [ ] フラグ未指定で従来通りの挙動になる
- [ ] `--lod-feature-growth 2` で LoD ごとの feature 数の伸びが概ね 2× 程度に収まる
- [ ] 全 LoD 合計の feature 数は変わらず、繰り越された feature は最終的にいずれかの LoD に配置される
- [ ] 不正値(0、負、NaN)で適切に拒否される