### PR TITLE
Lazy run dispatch + surface tile feature properties

### DIFF
--- a/cogp-js/src/reader.ts
+++ b/cogp-js/src/reader.ts
@@ -35,6 +35,11 @@ export interface OpenOptions {
 
 const DEFAULT_CACHE_MAX_ROWS = 1_000_000;
 
+// Cap on cumulative `num_rows` packed into a single coalesced fetch. A run
+// is read by one `parquetReadObjects` call that materializes every row in
+// the run as one array, so peak in-flight memory scales with this value.
+const RUN_MAX_ROWS = 50_000;
+
 export interface ReadOptions {
   /** Inclusive level index; defaults to the finest level (all row groups). */
   maxLevel?: number;
@@ -270,23 +275,45 @@ export class CogpReader {
       else missing.push(rg);
     }
 
-    // Phase 2: build runs of consecutive missing indices so hyparquet can
-    // pull their column chunks together, then dispatch each run as a single
-    // fetch. Each row group's slice promise is registered in the cache
-    // immediately so a second caller arriving while the run is mid-flight
-    // reuses the same Promise (single-flight) instead of issuing a duplicate.
-    const runs: Array<{ startRg: number; endRg: number }> = [];
+    // Phase 2: group consecutive missing indices into runs so hyparquet can
+    // pull their column chunks together. A run is also capped by cumulative
+    // num_rows: a single `parquetReadObjects` call materializes the entire
+    // run's rows in one array, so an unbounded run is the worst case for
+    // peak memory. The first row group in a run is always included even if
+    // it alone exceeds the cap (we can't fetch partial row groups).
+    const runs: Array<number[]> = [];
     {
       let i = 0;
       while (i < missing.length) {
-        let j = i;
-        while (j + 1 < missing.length && missing[j + 1]! === missing[j]! + 1) j++;
-        runs.push({ startRg: missing[i]!, endRg: missing[j]! });
-        i = j + 1;
+        const run: number[] = [missing[i]!];
+        let acc = Number(this.metadata.row_groups[missing[i]!]?.num_rows ?? 0);
+        let j = i + 1;
+        while (
+          j < missing.length &&
+          missing[j]! === missing[j - 1]! + 1 &&
+          acc < RUN_MAX_ROWS
+        ) {
+          run.push(missing[j]!);
+          acc += Number(this.metadata.row_groups[missing[j]!]?.num_rows ?? 0);
+          j++;
+        }
+        runs.push(run);
+        i = j;
       }
     }
+    const rgToRun = new Map<number, number[]>();
+    for (const run of runs) for (const rg of run) rgToRun.set(rg, run);
+    const dispatched = new WeakSet<number[]>();
 
-    for (const { startRg, endRg } of runs) {
+    // Each row group's slice promise is registered in the cache the moment
+    // its run is dispatched, so a second caller arriving while the run is
+    // mid-flight reuses the same Promise (single-flight) instead of issuing
+    // a duplicate.
+    const dispatchRun = (run: number[]) => {
+      if (dispatched.has(run)) return;
+      dispatched.add(run);
+      const startRg = run[0]!;
+      const endRg = run[run.length - 1]!;
       const rowStart = this.rowOffsets[startRg]!;
       const rowEnd = rowStart + this.sumRowsInRange(startRg, endRg);
       const readArgs: Record<string, unknown> = {
@@ -301,7 +328,7 @@ export class CogpReader {
         Record<string, unknown>[]
       >;
       let offset = 0;
-      for (let r = startRg; r <= endRg; r++) {
+      for (const r of run) {
         const start = offset;
         const n = Number(this.metadata.row_groups[r]?.num_rows ?? 0);
         offset += n;
@@ -310,11 +337,22 @@ export class CogpReader {
         this.rowGroupCache.set(cacheKey(r), slicePromise, n);
         promises.set(r, slicePromise);
       }
-    }
+    };
 
-    // Phase 3: yield each row group's rows in the requested order.
+    // Phase 3: dispatch each run only when iteration first reaches one of
+    // its row groups, then yield the row group's slice. If the caller breaks
+    // early (e.g. post-filter `maxRows` reached), later runs are never
+    // fetched.
     for (const rg of rgIndices) {
-      yield await promises.get(rg)!;
+      let p = promises.get(rg);
+      if (!p) {
+        const run = rgToRun.get(rg);
+        if (run) {
+          dispatchRun(run);
+          p = promises.get(rg);
+        }
+      }
+      yield await p!;
     }
   }
 

--- a/demo/src/main.ts
+++ b/demo/src/main.ts
@@ -42,6 +42,54 @@ const map = new maplibregl.Map({
 map.addControl(new maplibregl.NavigationControl({}), 'top-right');
 map.addControl(new maplibregl.ScaleControl({ unit: 'metric' }), 'bottom-left');
 
+const COGP_INTERACTIVE_LAYERS = ['cogp-fill', 'cogp-line', 'cogp-point'];
+
+map.on('click', (e) => {
+  const features = map.queryRenderedFeatures(e.point, { layers: COGP_INTERACTIVE_LAYERS });
+  const feature = features[0];
+  if (!feature) return;
+  new maplibregl.Popup({ maxWidth: '360px' })
+    .setLngLat(e.lngLat)
+    .setHTML(renderPropertiesHtml(feature.properties))
+    .addTo(map);
+});
+
+for (const layerId of COGP_INTERACTIVE_LAYERS) {
+  map.on('mouseenter', layerId, () => {
+    map.getCanvas().style.cursor = 'pointer';
+  });
+  map.on('mouseleave', layerId, () => {
+    map.getCanvas().style.cursor = '';
+  });
+}
+
+function renderPropertiesHtml(properties: Record<string, unknown> | null | undefined): string {
+  const entries = properties ? Object.entries(properties) : [];
+  if (entries.length === 0) {
+    return '<div class="cogp-popup"><em>No properties</em></div>';
+  }
+  entries.sort(([a], [b]) => a.localeCompare(b));
+  const rows = entries
+    .map(([k, v]) => `<tr><th>${escapeHtml(k)}</th><td>${escapeHtml(formatValue(v))}</td></tr>`)
+    .join('');
+  return `<div class="cogp-popup"><table>${rows}</table></div>`;
+}
+
+function formatValue(value: unknown): string {
+  if (value === null || value === undefined) return '';
+  if (typeof value === 'string') return value;
+  return String(value);
+}
+
+function escapeHtml(input: string): string {
+  return input
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
 map.on('load', () => {
   if (active) replaceCogpSource(active.url);
 });

--- a/demo/src/style.css
+++ b/demo/src/style.css
@@ -121,3 +121,33 @@ body {
   overflow-x: auto;
   max-height: 220px;
 }
+
+.cogp-popup {
+  max-height: 320px;
+  overflow: auto;
+  font-size: 12px;
+}
+
+.cogp-popup table {
+  border-collapse: collapse;
+  width: 100%;
+}
+
+.cogp-popup th,
+.cogp-popup td {
+  text-align: left;
+  vertical-align: top;
+  padding: 3px 6px;
+  border-bottom: 1px solid #eef0f5;
+  word-break: break-word;
+}
+
+.cogp-popup th {
+  color: #555;
+  font-weight: 600;
+  white-space: nowrap;
+}
+
+.cogp-popup td {
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+}

--- a/demo/src/tile-encoder.ts
+++ b/demo/src/tile-encoder.ts
@@ -12,12 +12,18 @@ export interface EncodeResult {
   featureCount: number;
 }
 
+export interface EncodeOptions {
+  excludeColumns?: ReadonlyArray<string>;
+}
+
 export function encodeTileRows(
   rows: ReadonlyArray<Record<string, unknown>>,
   geomColumn: string,
   tile: { z: number; x: number; y: number },
+  options: EncodeOptions = {},
 ): EncodeResult {
-  const fc = rowsToFeatureCollection(rows, geomColumn);
+  const exclude = new Set<string>([geomColumn, ...(options.excludeColumns ?? [])]);
+  const fc = rowsToFeatureCollection(rows, geomColumn, exclude);
   return {
     data: encodeMvt(fc, tile),
     featureCount: fc.features.length,
@@ -31,14 +37,47 @@ export function emptyTile(): ArrayBuffer {
 function rowsToFeatureCollection(
   rows: ReadonlyArray<Record<string, unknown>>,
   geomColumn: string,
+  excludeColumns: ReadonlySet<string>,
 ): FeatureCollection {
   const features: Feature[] = [];
   for (const row of rows) {
     const geometry = row[geomColumn] as Geometry | null | undefined;
     if (!geometry) continue;
-    features.push({ type: 'Feature', geometry, properties: {} });
+    features.push({
+      type: 'Feature',
+      geometry,
+      properties: buildProperties(row, excludeColumns),
+    });
   }
   return { type: 'FeatureCollection', features };
+}
+
+function buildProperties(
+  row: Record<string, unknown>,
+  excludeColumns: ReadonlySet<string>,
+): Record<string, string | number | boolean | null> {
+  const props: Record<string, string | number | boolean | null> = {};
+  for (const [key, value] of Object.entries(row)) {
+    if (excludeColumns.has(key)) continue;
+    props[key] = coerceMvtValue(value);
+  }
+  return props;
+}
+
+function coerceMvtValue(value: unknown): string | number | boolean | null {
+  if (value === null || value === undefined) return null;
+  const t = typeof value;
+  if (t === 'string' || t === 'number' || t === 'boolean') {
+    return value as string | number | boolean;
+  }
+  if (t === 'bigint') return (value as bigint).toString();
+  if (value instanceof Date) return value.toISOString();
+  if (value instanceof Uint8Array) return `<bytes:${value.byteLength}>`;
+  try {
+    return JSON.stringify(value, (_k, v) => (typeof v === 'bigint' ? v.toString() : v));
+  } catch {
+    return String(value);
+  }
 }
 
 function encodeMvt(fc: FeatureCollection, tile?: { z: number; x: number; y: number }): ArrayBuffer {

--- a/demo/src/tile-service.ts
+++ b/demo/src/tile-service.ts
@@ -129,15 +129,22 @@ async function buildCogpTile(
     maxLevel,
     maxRows: TILE_MAX_ROWS,
     maxBytes: TILE_MAX_BYTES,
-    columns: [geomColumn],
   });
 
-  const { data, featureCount } = encodeTileRows(rows, geomColumn, tile);
+  const { data, featureCount } = encodeTileRows(rows, geomColumn, tile, {
+    excludeColumns: bboxTopColumn(ds.reader, geomColumn),
+  });
   ds.servedTiles += 1;
   return {
     data,
     status: `Served ${ds.servedTiles} vector tiles. Last: ${featureCount} features at ${formatGsd(targetGsd)}/px (level <= ${maxLevel}).`,
   };
+}
+
+function bboxTopColumn(reader: CogpReader, geomColumn: string): string[] {
+  const path = reader.geo.columns[geomColumn]?.covering?.bbox?.xmin;
+  const top = path?.[0];
+  return top ? [top] : [];
 }
 
 function tileBbox(z: number, x: number, y: number) {


### PR DESCRIPTION
## Summary
- **cogp-js**: fixes a hidden eager-dispatch bug in `streamRowGroups`. Coalesced `parquetReadObjects` calls used to be issued for every run up front, so `readRows` callers that hit `maxRows` after the first row group still paid for every later fetch. Dispatch is now deferred until iteration reaches each run, and a `RUN_MAX_ROWS = 50_000` cap prevents a single fetch from materializing an unbounded array when many consecutive row groups intersect the query bbox.
- **demo**: drops the `columns: [geomColumn]` projection so all non-geometry, non-bbox columns flow through `encodeTileRows` and become MVT feature properties. Adds a click-to-popup interaction that shows the clicked feature's attribute table.

## Test plan
- [x] cogp-js typecheck + build pass.
- [ ] Load a large dataset in the demo and confirm the browser no longer crashes when many row groups overlap a tile.
- [ ] Verify that `maxRows` actually short-circuits row-group fetches (e.g. via Network panel: only the first run's column-chunk range requests fire when survivors quickly reach the cap).
- [ ] Click a feature in the demo and confirm the popup shows non-geometry attributes (numbers, strings, dates, etc.) with the bbox covering struct excluded.
