### PR TITLE
demo: drop hard-coded maxBytes from viewport read

### DIFF
--- a/demo/src/cogp-worker.ts
+++ b/demo/src/cogp-worker.ts
@@ -52,7 +52,7 @@ async function readViewport(
   }
   const geomColumn = ds.reader.primaryGeometryColumn;
   const maxLevel = ds.reader.selectLevel(targetGsd);
-  const rows = await ds.reader.readRows({ bbox, maxLevel, maxRows: VIEWPORT_MAX_ROWS, maxBytes: 100000000 });
+  const rows = await ds.reader.readRows({ bbox, maxLevel, maxRows: VIEWPORT_MAX_ROWS });
 
   const features: Feature[] = [];
   const skip = new Set<string>([geomColumn]);


### PR DESCRIPTION
Stray `maxBytes: 100000000` left in the viewport read call from earlier debugging. Removes it so viewport reads rely on the row-group bbox prune and `maxRows` cap only.