### PR TITLE
Add 'When COGP works well' section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,12 @@ https://github.com/user-attachments/assets/10d0390c-95ab-45e5-8503-6cbdbb015c93
 
 https://github.com/user-attachments/assets/fd15605a-7d66-41a3-884d-c735e3467708
 
+## When COGP works well
+
+COGP is particularly well suited to datasets of many small, well-distributed features — such as POIs or building footprints — where dropping later row groups still yields a meaningful overview.
+
+Because COGP does not simplify geometries, datasets dominated by large, complex geometries (coastlines, rivers, road networks, administrative boundaries) cannot avoid transferring heavy per-feature payloads, making them less suitable for progressive streaming. Other COGP benefits — GeoParquet 1.1 compatibility, fast overview rendering, and efficient AoI-based queries — still apply.
+
 ## Specification
 
 See [`SPEC.md`](./SPEC.md) for the normative specification.


### PR DESCRIPTION
## Summary
- Adds a brief section describing the data shapes COGP is best suited for (POIs, buildings) and the cases where progressive streaming benefits are diminished (large/complex geometries like coastlines, rivers, road networks, administrative boundaries).
- Clarifies that even for less ideal data, GeoParquet 1.1 compatibility, overview row-group ordering, and AoI-based query benefits still apply.

## Test plan
- [x] Render README on GitHub and confirm formatting