### PR TITLE
Keep the COGP profile at version 0.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ A proof-of-concept exploring this layout exists at [Kanahiro/yosegi](https://git
 
 ## Status and feedback
 
-COGP v1.0 is a draft. Feedback, issues, and discussion are welcome via GitHub Issues.
+COGP v0.1 is a draft. Feedback, issues, and discussion are welcome via GitHub Issues.
 
 ## License
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -1,6 +1,6 @@
 ---
 title: Cloud Optimized GeoParquet Profile (COGP)
-version: "1.0.0"
+version: "0.1.0"
 status: Draft
 scope: A cloud-optimized progressive rendering profile for GeoParquet 1.1
 ---
@@ -109,7 +109,7 @@ precision.
 
 ## 5. Requirements
 
-A COGP v1.0 file MUST satisfy the following requirements.
+A COGP v0.1 file MUST satisfy the following requirements.
 
 ### 5.1 GeoParquet compatibility
 
@@ -130,7 +130,7 @@ where `<primary_column>` is the value of the GeoParquet `primary_column` field.
 
 Each of the bounding box columns (`xmin`, `ymin`, `xmax`, `ymax`) referenced by this covering MUST have Parquet row group min/max statistics present, so that readers can perform spatial pruning at row group granularity.
 
-For COGP v1.0, geometries in the primary geometry column MUST NOT cross the antimeridian in a way that makes GeoParquet bbox covering unsuitable for spatial pruning. Producers SHOULD split such geometries or use another representation before writing a COGP file.
+For COGP v0.1, geometries in the primary geometry column MUST NOT cross the antimeridian in a way that makes GeoParquet bbox covering unsuitable for spatial pruning. Producers SHOULD split such geometries or use another representation before writing a COGP file.
 
 ### 5.2 Physical ordering
 
@@ -263,7 +263,7 @@ Readers MUST NOT interpret `cogp` metadata with an unsupported major version as 
 
 ```json
 {
-  "version": "1.0.0",
+  "version": "0.1.0",
   "levels": [
     {
       "row_group_end": 0,
@@ -285,7 +285,7 @@ Readers MUST NOT interpret `cogp` metadata with an unsupported major version as 
 
 ```json
 {
-  "version": "1.0.0",
+  "version": "0.1.0",
   "lods_column": "geometry_lods",
   "levels": [
     {

--- a/cogp-js/demo/package-lock.json
+++ b/cogp-js/demo/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cogp-demo",
-  "version": "0.0.0",
+  "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cogp-demo",
-      "version": "0.0.0",
+      "version": "0.1.0",
       "dependencies": {
         "cogp": "file:..",
         "maplibre-gl": "^4.7.0"

--- a/cogp-js/demo/package.json
+++ b/cogp-js/demo/package.json
@@ -1,7 +1,7 @@
 {
   "name": "cogp-demo",
   "private": true,
-  "version": "0.0.0",
+  "version": "0.1.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/cogp-js/src/meta.ts
+++ b/cogp-js/src/meta.ts
@@ -55,10 +55,10 @@ export function parseCogpMeta(json: string): CogpMeta {
   if (!Array.isArray(parsed.levels) || parsed.levels.length === 0) {
     throw new Error('cogp metadata: `levels` must be a non-empty array');
   }
-  const major = Number.parseInt(parsed.version.split('.')[0] ?? '', 10);
-  if (major !== 1) {
+  const version = /^(\d+)\.(\d+)\.(\d+)$/.exec(parsed.version);
+  if (!version || Number(version[1]) !== 0) {
     throw new Error(
-      `cogp metadata: unsupported major version \`${parsed.version}\` (this reader implements 1.x)`,
+      `cogp metadata: unsupported version \`${parsed.version}\` (expected MAJOR.MINOR.PATCH with major 0)`,
     );
   }
   if (

--- a/cogp-js/test/reader.test.mjs
+++ b/cogp-js/test/reader.test.mjs
@@ -6,10 +6,10 @@ import { parquetWriteBuffer } from 'hyparquet-writer';
 
 import { CogpReader, parseCogpMeta, selectLevelByResolution } from '../dist/index.js';
 
-test('COGP 1 metadata and resolution selection', () => {
+test('COGP 0.1 metadata and resolution selection', () => {
   const metadata = parseCogpMeta(
     JSON.stringify({
-      version: '1.0.0',
+      version: '0.1.0',
       lods_column: 'geometry_lods',
       levels: [
         { row_group_end: 0, resolution: 1000 },
@@ -21,8 +21,18 @@ test('COGP 1 metadata and resolution selection', () => {
   assert.equal(selectLevelByResolution(metadata.levels, 500), 0);
   assert.equal(selectLevelByResolution(metadata.levels, 50), 1);
   assert.throws(
-    () => parseCogpMeta('{"version":"0.1.0","levels":[{"row_group_end":0,"gsd":1}]}'),
-    /unsupported major version/,
+    () =>
+      parseCogpMeta(
+        '{"version":"1.0.0","levels":[{"row_group_end":0,"resolution":1}]}',
+      ),
+    /unsupported version/,
+  );
+  assert.throws(
+    () =>
+      parseCogpMeta(
+        '{"version":"0.x.0","levels":[{"row_group_end":0,"resolution":1}]}',
+      ),
+    /unsupported version/,
   );
 });
 
@@ -127,7 +137,7 @@ function makeCogp({ storedLodLevels = [0, 2] } = {}) {
     },
   };
   const cogp = {
-    version: '1.0.0',
+    version: '0.1.0',
     lods_column: 'geometry_lods',
     levels: [
       { row_group_end: 0, resolution: 1000 },

--- a/cogp-rs/README.md
+++ b/cogp-rs/README.md
@@ -137,7 +137,7 @@ The output file:
   selected by `--lod-interval`;
 - omits the sidecar for Point/MultiPoint-only files, whose readers use the
   primary geometry WKB;
-- writes `cogp` v1.0 metadata listing `row_group_end`, `resolution`, and
+- writes `cogp` v0.1 metadata listing `row_group_end`, `resolution`, and
   `lods_column` when a sidecar is present.
 
 `lods_column` is optional for every geometry type. This converter emits it when

--- a/cogp-rs/src/meta.rs
+++ b/cogp-rs/src/meta.rs
@@ -3,8 +3,22 @@ use std::collections::BTreeMap;
 
 pub const COGP_METADATA_KEY: &str = "cogp";
 pub const GEO_METADATA_KEY: &str = "geo";
-pub const COGP_VERSION: &str = "1.0.0";
+pub const COGP_VERSION: &str = "0.1.0";
 pub const GEOPARQUET_VERSION: &str = "1.1.0";
+
+/// Parse the profile's required `MAJOR.MINOR.PATCH` version shape.
+///
+/// Keeping this strict avoids accidentally accepting values such as `0.1`
+/// or `0.x.0` when checking reader compatibility.
+pub(crate) fn parse_cogp_version(version: &str) -> Option<(u32, u32, u32)> {
+    let mut parts = version.split('.');
+    let parsed = (
+        parts.next()?.parse().ok()?,
+        parts.next()?.parse().ok()?,
+        parts.next()?.parse().ok()?,
+    );
+    (parts.next().is_none()).then_some(parsed)
+}
 
 /// Parse the COGP rendering-sidecar child naming contract.
 ///
@@ -167,9 +181,10 @@ mod tests {
         assert_eq!(GEOPARQUET_VERSION, "1.1.0");
         assert_eq!(COGP_METADATA_KEY, "cogp");
         assert_eq!(GEO_METADATA_KEY, "geo");
-        // COGP_VERSION must be SemVer-like; major must parse.
-        let major: u32 = COGP_VERSION.split('.').next().unwrap().parse().unwrap();
-        assert_eq!(major, 1);
+        assert_eq!(COGP_VERSION, "0.1.0");
+        assert_eq!(parse_cogp_version(COGP_VERSION), Some((0, 1, 0)));
+        assert_eq!(parse_cogp_version("0.1"), None);
+        assert_eq!(parse_cogp_version("0.x.0"), None);
     }
 
     #[test]

--- a/cogp-rs/src/reader.rs
+++ b/cogp-rs/src/reader.rs
@@ -42,7 +42,10 @@ use parquet::arrow::async_reader::{
 #[cfg(feature = "object_store")]
 pub use parquet::arrow::async_reader::ParquetObjectReader;
 
-use crate::meta::{lod_level_index, CogpMeta, GeoMeta, Level, COGP_METADATA_KEY, GEO_METADATA_KEY};
+use crate::meta::{
+    lod_level_index, parse_cogp_version, CogpMeta, GeoMeta, Level, COGP_METADATA_KEY,
+    GEO_METADATA_KEY,
+};
 
 /// Cached COGP file handle. Holds the parsed footer + COGP/GeoParquet metadata.
 /// Cheap to clone (the underlying `ArrowReaderMetadata` is `Arc`-backed) and
@@ -311,14 +314,10 @@ fn parse_cogp_kv(metadata: &Arc<ParquetMetaData>) -> Result<(GeoMeta, CogpMeta)>
         .ok_or_else(|| anyhow!("missing `cogp` key-value metadata"))?;
     let cogp_meta: CogpMeta = serde_json::from_str(cogp_str)
         .map_err(|e| anyhow!("`cogp` metadata is not valid JSON: {e}"))?;
-    let major = cogp_meta
-        .version
-        .split('.')
-        .next()
-        .and_then(|value| value.parse::<u32>().ok());
-    if major != Some(1) {
+    let version = parse_cogp_version(&cogp_meta.version);
+    if !matches!(version, Some((0, _, _))) {
         return Err(anyhow!(
-            "unsupported cogp version `{}`; this reader implements 1.x",
+            "unsupported cogp version `{}`; expected MAJOR.MINOR.PATCH with major 0",
             cogp_meta.version
         ));
     }

--- a/cogp-rs/src/validate.rs
+++ b/cogp-rs/src/validate.rs
@@ -5,7 +5,7 @@ use parquet::file::statistics::Statistics;
 use std::fs::File;
 use std::path::Path;
 
-use crate::meta::lod_level_index;
+use crate::meta::{lod_level_index, parse_cogp_version};
 
 use crate::meta::{CogpMeta, GeoMeta, COGP_METADATA_KEY, GEO_METADATA_KEY};
 
@@ -53,7 +53,7 @@ pub fn run(path: &Path) -> Result<()> {
     };
     if !geo.version.starts_with("1.") {
         warnings.push(format!(
-            "GeoParquet version is `{}`; COGP v1.0 targets 1.1.x",
+            "GeoParquet version is `{}`; COGP v0.1 targets 1.1.x",
             geo.version
         ));
     }
@@ -98,15 +98,9 @@ pub fn run(path: &Path) -> Result<()> {
         }
     };
 
-    let major: u32 = cogp
-        .version
-        .split('.')
-        .next()
-        .and_then(|s| s.parse().ok())
-        .unwrap_or(0);
-    if major != 1 {
+    if !matches!(parse_cogp_version(&cogp.version), Some((0, _, _))) {
         errors.push(format!(
-            "unsupported cogp major version `{}`; this validator implements 1.x",
+            "unsupported cogp version `{}`; expected MAJOR.MINOR.PATCH with major 0",
             cogp.version
         ));
     }
@@ -297,7 +291,7 @@ pub fn run(path: &Path) -> Result<()> {
 
 fn print_report(path: &Path, errors: &[String], warnings: &[String]) {
     if errors.is_empty() {
-        println!("OK: {} conforms to COGP v1.0", path.display());
+        println!("OK: {} conforms to COGP v0.1", path.display());
     } else {
         println!("FAIL: {} ({} error(s))", path.display(), errors.len());
     }


### PR DESCRIPTION
## Summary

- keep the COGP profile and on-disk `cogp.version` at `0.1.0`
- align the specification, examples, Rust producer/validator/reader, TypeScript reader, tests, and documentation
- align the private browser demo package version with the rest of the monorepo
- validate the required `MAJOR.MINOR.PATCH` shape instead of loosely parsing only the leading number

## Why

The LOD work is still part of the `0.1.0` draft. It should not imply that the profile has reached `1.0.0`, and every implementation should apply the same compatibility rule.

## Impact

Rust and TypeScript readers validate the required `MAJOR.MINOR.PATCH` shape and accept the profile's major version `0`. The producer emits exactly `0.1.0`.

## Validation

- `cargo fmt --check`
- `cargo test --all-features` (72 tests)
- `cargo clippy --all-features --all-targets -- -D warnings`
- `npm test` in `cogp-js/` (5 tests)
- `npm run build` in `cogp-js/demo/`
- `git diff --check`
