### PR TITLE
Separate specification and library licenses

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,4 +110,9 @@ COGP v0.1 is a draft. Feedback, issues, and discussion are welcome via GitHub Is
 
 ## License
 
-This specification is licensed under [Creative Commons Attribution 4.0 International (CC BY 4.0)](https://creativecommons.org/licenses/by/4.0/). See [`LICENSE`](./LICENSE) for details.
+- The COGP specification is licensed under [Creative Commons Attribution 4.0
+  International (CC BY 4.0)](https://creativecommons.org/licenses/by/4.0/).
+  See [`LICENSE`](./LICENSE).
+- The Rust and TypeScript libraries are licensed under the MIT License. See
+  [`cogp-rs/LICENSE`](./cogp-rs/LICENSE) and
+  [`cogp-js/LICENSE`](./cogp-js/LICENSE).

--- a/cogp-js/LICENSE
+++ b/cogp-js/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Kanahiro Iguchi
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/cogp-js/README.md
+++ b/cogp-js/README.md
@@ -24,3 +24,7 @@ npm run build
 ```
 
 Generated `dist/` directories, `node_modules/`, and local Parquet files are not tracked.
+
+## License
+
+Licensed under the [MIT License](./LICENSE).

--- a/cogp-js/demo/package-lock.json
+++ b/cogp-js/demo/package-lock.json
@@ -19,7 +19,7 @@
     "..": {
       "name": "cogp",
       "version": "0.1.0",
-      "license": "CC-BY-4.0",
+      "license": "MIT",
       "dependencies": {
         "hyparquet": "^1.10.0",
         "hyparquet-compressors": "^1.1.1"

--- a/cogp-js/package-lock.json
+++ b/cogp-js/package-lock.json
@@ -7,7 +7,7 @@
     "": {
       "name": "cogp",
       "version": "0.1.0",
-      "license": "CC-BY-4.0",
+      "license": "MIT",
       "dependencies": {
         "hyparquet": "^1.10.0",
         "hyparquet-compressors": "^1.1.1"

--- a/cogp-js/package.json
+++ b/cogp-js/package.json
@@ -2,7 +2,7 @@
   "name": "cogp",
   "version": "0.1.0",
   "description": "Cloud Optimized GeoParquet Profile (COGP) reader for the web.",
-  "license": "CC-BY-4.0",
+  "license": "MIT",
   "type": "module",
   "exports": {
     ".": {

--- a/cogp-rs/Cargo.toml
+++ b/cogp-rs/Cargo.toml
@@ -3,7 +3,7 @@ name = "cogp"
 version = "0.1.0"
 edition = "2021"
 description = "Reference CLI for the Cloud Optimized GeoParquet Profile (COGP)"
-license = "CC-BY-4.0"
+license = "MIT"
 
 [[bin]]
 name = "cogp"

--- a/cogp-rs/LICENSE
+++ b/cogp-rs/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Kanahiro Iguchi
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/cogp-rs/README.md
+++ b/cogp-rs/README.md
@@ -327,3 +327,7 @@ tools/bench_cogp.py \
 
 Use `--reuse-outputs` with `--baseline-output` / `--candidate-output` to
 reanalyze existing converted files without rerunning `convert`.
+
+## License
+
+Licensed under the [MIT License](./LICENSE).


### PR DESCRIPTION
## Summary

- keep the COGP specification under CC BY 4.0 at the repository root
- license the Rust and TypeScript implementations under MIT
- add MIT license files to both library directories
- align Cargo, npm, lockfile, and README license metadata

## Why

The specification and its implementations serve different reuse needs. CC BY
4.0 remains appropriate for the normative specification, while MIT gives
library users a conventional permissive software license. Directory-local
license files make that boundary explicit and ensure each published package
includes the correct terms.

## Impact

The normative specification remains CC BY 4.0. `cogp-rs` and `cogp-js`,
including their packaged artifacts, are licensed under MIT. No runtime behavior
or public API changes.

## Validation

- `cargo test --all-features` (72 tests)
- `npm test` (5 tests)
- `cargo metadata --no-deps --format-version 1`
- `cargo package --list --allow-dirty` (MIT `LICENSE` included)
- `npm pack --dry-run --json` (MIT `LICENSE` included)
- `git diff --check`
