### PR TITLE
Refresh viewport during map movement

### DIFF
--- a/cogp-js/demo/src/main.ts
+++ b/cogp-js/demo/src/main.ts
@@ -8,6 +8,7 @@ import {
 } from './dataset-service';
 
 const COGP_SOURCE_ID = 'cogp';
+const VIEWPORT_REFRESH_INTERVAL_MS = 150;
 
 const map = new maplibregl.Map({
   container: 'map',
@@ -93,8 +94,11 @@ map.on('load', () => {
   if (active) installCogpSource();
 });
 
-map.on('moveend', () => {
-  if (active) void refreshViewport();
+map.on('move', () => {
+  if (active) {
+    viewportToken += 1;
+    requestViewportRefresh();
+  }
 });
 
 function installCogpSource(): void {
@@ -139,7 +143,8 @@ function installCogpSource(): void {
     },
   });
 
-  void refreshViewport();
+  viewportToken += 1;
+  requestViewportRefresh(true);
 }
 
 function removeCogpLayersAndSource(): void {
@@ -154,13 +159,47 @@ function emptyFC(): FeatureCollection {
 }
 
 let viewportToken = 0;
+let viewportRefreshTimer: number | null = null;
+let viewportRefreshInFlight = false;
+let viewportRefreshRequested = false;
+let lastViewportRefreshStartedAt = -Infinity;
+
+function requestViewportRefresh(immediate = false): void {
+  viewportRefreshRequested = true;
+  if (viewportRefreshInFlight) return;
+
+  if (viewportRefreshTimer !== null) {
+    if (!immediate) return;
+    clearTimeout(viewportRefreshTimer);
+  }
+
+  const elapsed = performance.now() - lastViewportRefreshStartedAt;
+  const delay = immediate ? 0 : Math.max(0, VIEWPORT_REFRESH_INTERVAL_MS - elapsed);
+  viewportRefreshTimer = window.setTimeout(() => {
+    viewportRefreshTimer = null;
+    void runViewportRefresh();
+  }, delay);
+}
+
+async function runViewportRefresh(): Promise<void> {
+  if (!viewportRefreshRequested || viewportRefreshInFlight) return;
+  viewportRefreshRequested = false;
+  viewportRefreshInFlight = true;
+  lastViewportRefreshStartedAt = performance.now();
+  try {
+    await refreshViewport();
+  } finally {
+    viewportRefreshInFlight = false;
+    if (viewportRefreshRequested) requestViewportRefresh();
+  }
+}
 
 async function refreshViewport(): Promise<void> {
   const ds = active;
   if (!ds) return;
   const source = map.getSource(COGP_SOURCE_ID) as maplibregl.GeoJSONSource | undefined;
   if (!source) return;
-  const myToken = ++viewportToken;
+  const myToken = viewportToken;
   const b = map.getBounds();
   const bbox = {
     minX: b.getWest(),


### PR DESCRIPTION
## What changed

- Refresh the COGP demo viewport from MapLibre `move` events instead of waiting for `moveend`.
- Throttle viewport reads to a 150 ms minimum interval.
- Allow only one viewport read in flight and queue the latest position while it runs.
- Discard completed reads when the map moved after they started.

## Why

Waiting for `moveend` leaves the displayed data stale throughout a pan or zoom interaction. Refreshing on every animation frame would create excessive overlapping reads. The scheduler keeps the map responsive during movement without allowing request fan-out.

## Validation

- `pnpm --filter cogp-demo build`
- `git diff --check`
