### PR TITLE
Add deterministic geometry overview pipeline

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -41,6 +41,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "allocator-api2"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
+
+[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -104,6 +110,15 @@ name = "anyhow"
 version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+
+[[package]]
+name = "approx"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cab112f0a86d568ea0e627cc1d6be74a1e9cd55214684db5561995f6dad897c6"
+dependencies = [
+ "num-traits",
+]
 
 [[package]]
 name = "arrow"
@@ -321,7 +336,7 @@ checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -450,7 +465,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -472,6 +487,8 @@ dependencies = [
  "bytes",
  "clap",
  "futures",
+ "geo",
+ "i_overlay",
  "parquet",
  "rayon",
  "serde",
@@ -570,7 +587,16 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "earcut"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88459a2a8e3a514b6e6de38cf3aaa9250a894cb098f74a932db77fcc8341b6d0"
+dependencies = [
+ "num-traits",
 ]
 
 [[package]]
@@ -600,6 +626,18 @@ dependencies = [
  "bitflags",
  "rustc_version",
 ]
+
+[[package]]
+name = "float_next_after"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37007738a80ea34f969af54a3390dd72cacdef654974cfd449c9f6f72dbaac10"
+
+[[package]]
+name = "foldhash"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
 name = "form_urlencoded"
@@ -666,7 +704,7 @@ checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -696,6 +734,51 @@ dependencies = [
  "memchr",
  "pin-project-lite",
  "slab",
+]
+
+[[package]]
+name = "geo"
+version = "0.33.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30eb1fdc57c1e5cfd11826fe0caec4b9dc7901f3758263bb506228d88c8d9e9a"
+dependencies = [
+ "earcut",
+ "float_next_after",
+ "geo-types",
+ "geographiclib-rs",
+ "i_overlay",
+ "log",
+ "num-traits",
+ "rand",
+ "rand_pcg",
+ "robust",
+ "rstar",
+ "sif-itree",
+ "spade",
+]
+
+[[package]]
+name = "geo-types"
+version = "0.7.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "777d18aa0f12f8b285331cd867133ee14422b3f023f6d388034c47d43e28786a"
+dependencies = [
+ "approx",
+ "num-traits",
+ "rayon",
+ "rstar",
+ "serde",
+ "spade",
+ "thiserror",
+]
+
+[[package]]
+name = "geographiclib-rs"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c5a7f08910fd98737a6eda7568e7c5e645093e073328eeef49758cfe8b0489c7"
+dependencies = [
+ "libm",
 ]
 
 [[package]]
@@ -734,16 +817,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "hash32"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47d60b12902ba28e2730cd37e95b8c9223af2808df9e902d4df49588d1470606"
+dependencies = [
+ "byteorder",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash",
+]
 
 [[package]]
 name = "hashbrown"
 version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+
+[[package]]
+name = "heapless"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bfb9eb618601c89945a70e254898da93b13be0388091d42117462b265bb3fad"
+dependencies = [
+ "hash32",
+ "stable_deref_trait",
+]
 
 [[package]]
 name = "heck"
@@ -766,6 +873,52 @@ name = "humantime"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "135b12329e5e3ce057a9f972339ea52bc954fe1e9358ef27f95e89716fbc5424"
+
+[[package]]
+name = "i_float"
+version = "1.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "813145bb0ad5b60f55cbbf3c74cdceda1c0a9d253b35c4cc36ae0df7887cb78f"
+dependencies = [
+ "libm",
+]
+
+[[package]]
+name = "i_key_sort"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d73d122b937fca067feb0ad74f62388920272b27c356d4df2d0cfdd59e044cf0"
+dependencies = [
+ "rayon",
+]
+
+[[package]]
+name = "i_overlay"
+version = "4.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8dd314b4668e2b3a12508f2e125558c82a6c0a8636fa5107a900f79ce414e450"
+dependencies = [
+ "i_float",
+ "i_key_sort",
+ "i_shape",
+ "i_tree",
+ "rayon",
+]
+
+[[package]]
+name = "i_shape"
+version = "1.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa9eac533d7509a8ab87672b60ac610c17240f9ea4851d26227689fdfe349c8"
+dependencies = [
+ "i_float",
+]
+
+[[package]]
+name = "i_tree"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4804bdc1dc124eb7e1aa9e144ecc04096bcf787a10a15fa44af682b51f0f6cce"
 
 [[package]]
 name = "iana-time-zone"
@@ -1291,6 +1444,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
+name = "rand"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
+dependencies = [
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
+
+[[package]]
+name = "rand_pcg"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caa0f4137e1c0a72f4c651489402276c8e8e1cf081f3b0ba156d2cbeef09e86a"
+dependencies = [
+ "rand_core",
+]
+
+[[package]]
 name = "rayon"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1347,6 +1524,23 @@ name = "regex-syntax"
 version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
+
+[[package]]
+name = "robust"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e27ee8bb91ca0adcf0ecb116293afa12d393f9c2b9b9cd54d33e8078fe19839"
+
+[[package]]
+name = "rstar"
+version = "0.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "421400d13ccfd26dfa5858199c30a5d76f9c54e0dba7575273025b43c5175dbb"
+dependencies = [
+ "heapless",
+ "num-traits",
+ "smallvec",
+]
 
 [[package]]
 name = "rustc_version"
@@ -1414,7 +1608,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1435,6 +1629,12 @@ name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "sif-itree"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7f45b8998ced5134fb1d75732c77842a3e888f19c1ff98481822e8fbfbf930b"
 
 [[package]]
 name = "simdutf8"
@@ -1461,6 +1661,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b6b67fb9a61334225b5b790716f609cd58395f895b3fe8b328786812a40bc3b"
 
 [[package]]
+name = "spade"
+version = "2.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9699399fd9349b00b184f5635b074f9ec93afffef30c853f8c875b32c0f8c7fa"
+dependencies = [
+ "hashbrown 0.16.1",
+ "num-traits",
+ "robust",
+ "smallvec",
+]
+
+[[package]]
 name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1484,6 +1696,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "syn"
+version = "3.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6275cddf4610d1775e6d1fe9469b2e77d0f39fd98fb7450901b821e0c53649f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
 name = "synstructure"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1491,27 +1714,27 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "thiserror"
-version = "2.0.18"
+version = "2.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
+checksum = "ec86235f5fcc2a73650310756d2ac5b138a5780bbbdfae3eeccec992c435ba4f"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.18"
+version = "2.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
+checksum = "bc04cd3e1236dd4a98afca4569f2deb3f120e5422a4023be2cb683f8486292af"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -1563,7 +1786,7 @@ checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1585,7 +1808,7 @@ checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1696,7 +1919,7 @@ dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "wasm-bindgen-shared",
 ]
 
@@ -1740,7 +1963,7 @@ checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1751,7 +1974,7 @@ checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1818,7 +2041,7 @@ checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "synstructure",
 ]
 
@@ -1839,7 +2062,7 @@ checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1859,7 +2082,7 @@ checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "synstructure",
 ]
 
@@ -1893,7 +2116,7 @@ checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A GeoParquet profile for progressive map rendering and partial access over HTTP 
 
 A COGP file is a valid [GeoParquet 1.1](https://geoparquet.org/) file whose row groups are physically ordered from coarse to fine rendering detail, with file-level metadata describing where each level ends.
 
-COGP is **feature-level**: it reorders features across row groups; it does not simplify, aggregate, or duplicate them. Each source feature appears in exactly one row group, with its geometry preserved verbatim.
+COGP is **feature-level**: it places each source feature in exactly one row group and keeps the primary geometry lossless. Optional scale-specific WKB columns simplify that same row for rendering and become NULL after their linked level boundary.
 
 A COGP-aware reader can stream just the leading row groups needed for its target rendering resolution and stop. A reader that does not understand the profile can ignore the `cogp` metadata and read the file as ordinary GeoParquet 1.1.
 
@@ -18,7 +18,7 @@ COGP is informed by several existing cloud-optimized and progressive rendering p
 - Cloud Optimized Point Cloud: remaining a valid LAZ file while adding thinning and multi-resolution level concepts;
 - tippecanoe: design choice to avoid rendering every feature literally at low zoom levels.
 
-COGP applies these ideas at the GeoParquet row group level. Unlike raster overviews or vector tile simplification pipelines, COGP keeps each feature geometry unchanged and places each source feature in exactly one level.
+COGP applies these ideas at the GeoParquet row group and column-chunk levels. Feature rows are never duplicated; rendering overviews reduce vertex detail while the primary geometry remains unchanged.
 
 ## Why
 
@@ -56,7 +56,7 @@ https://github.com/user-attachments/assets/7daf178e-28b0-4440-845d-ee8f74fa5062
 
 COGP is particularly well suited to datasets of many small, well-distributed features — such as POIs or building footprints — where dropping later row groups still yields a meaningful overview.
 
-Because COGP does not simplify geometries, datasets dominated by large, complex geometries (coastlines, rivers, road networks, administrative boundaries) have relatively larger per-feature payloads, so the Row Group size should be tuned to optimize progressive streaming. Other COGP benefits — GeoParquet 1.1 compatibility, fast overview rendering, and efficient AoI-based queries — still apply.
+Datasets dominated by large, complex geometries (coastlines, rivers, road networks, administrative boundaries) benefit from optional scale-specific geometry overviews. Each overview declares its spatial tolerance independently from the feature-level boundary it covers; the final overview covers the complete feature ladder so rendering can avoid raw WKB, while the lossless primary geometry remains available for analysis.
 
 ## Specification
 
@@ -101,7 +101,7 @@ A proof-of-concept exploring this layout exists at [Kanahiro/yosegi](https://git
 
 ## Status and feedback
 
-COGP v0.1 is an early draft. Feedback, issues, and discussion are welcome via GitHub Issues.
+COGP v0.2 is an early draft. Feedback, issues, and discussion are welcome via GitHub Issues.
 
 ## License
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -1,6 +1,6 @@
 ---
 title: Cloud Optimized GeoParquet Profile (COGP)
-version: "0.1.0"
+version: "0.2.0"
 status: Draft
 scope: A cloud-optimized progressive rendering profile for GeoParquet 1.1
 license: CC BY 4.0
@@ -19,7 +19,7 @@ A COGP file is:
 3. organized so that each level ends at a Parquet row group boundary;
 4. annotated with minimal metadata describing those level boundaries.
 
-COGP is feature-level: it reorders features across row groups; it does not simplify, aggregate, or duplicate them.
+COGP keeps a lossless primary geometry while allowing sparse, scale-specific WKB columns for rendering. Feature rows are reordered but never duplicated.
 
 ## 2. Motivation
 
@@ -39,13 +39,13 @@ The core idea is:
 
 > Earlier row groups contain features that are independently meaningful at coarse display resolutions. Later row groups add features that are only independently meaningful at finer display resolutions.
 
-COGP is a **feature-level progressive subset**, not a geometry-decimation scheme:
+COGP's row layout is a **feature-level progressive subset**:
 
 * each source feature is placed, in full, in exactly one row group;
-* a feature's geometry is preserved verbatim — vertices, bends, and detail within a feature are never removed or simplified by this profile;
+* a feature's primary geometry is preserved verbatim;
 * features are assigned to the coarsest level at which they become independently renderable as whole features.
 
-Unlike COG (TIFF) overviews or tile pyramids, COGP does not duplicate features across levels, and does not produce simplified geometries.
+Unlike a tile pyramid, COGP does not duplicate rows across levels. Optional geometry overview columns contain simplified rendering copies and are sparse outside the row prefix where they apply.
 
 A reader can choose how many leading row groups to load based on its target rendering resolution.
 
@@ -73,7 +73,10 @@ The value is always expressed in meters of ground distance at the geographic loc
 
 For example, a level with `gsd` equal to `1000` represents independently meaningful units at approximately 1000 meters or larger, while finer units are deferred to later levels.
 
-Because COGP is feature-level (see Section 3), `gsd` describes the threshold at which whole features become independently meaningful, not the threshold at which individual vertices within a feature are kept or removed. A feature placed in a coarse level retains its full geometry, including fine internal detail.
+For feature levels, `gsd` describes the threshold at which whole features
+become independently meaningful. Geometry precision is described separately by
+each overview's `tolerance_meters`; linking an overview to a level defines only
+which feature prefix that column covers.
 
 This may apply to deferring features such as:
 
@@ -86,7 +89,7 @@ This value is rendering-oriented. It does not guarantee positional accuracy, top
 
 ## 5. Requirements
 
-A COGP v0.1 file MUST satisfy the following requirements.
+A COGP v0.2 file MUST satisfy the following requirements.
 
 ### 5.1 GeoParquet compatibility
 
@@ -100,9 +103,15 @@ geo.columns[<primary_column>].covering.bbox
 
 where `<primary_column>` is the value of the GeoParquet `primary_column` field.
 
+The primary geometry column's GeoParquet `geometry_types` array MUST be
+non-empty and MUST describe exactly one topological family: Point/MultiPoint,
+LineString/MultiLineString, or Polygon/MultiPolygon. Singular and Multi variants
+of the same family MAY coexist; geometry families MUST NOT be mixed in one COGP
+file. GeometryCollection is not supported by this profile.
+
 Each of the bounding box columns (`xmin`, `ymin`, `xmax`, `ymax`) referenced by this covering MUST have Parquet row group min/max statistics present, so that readers can perform spatial pruning at row group granularity.
 
-For COGP v0.1, geometries in the primary geometry column MUST NOT cross the antimeridian in a way that makes GeoParquet bbox covering unsuitable for spatial pruning. Producers SHOULD split such geometries or use another representation before writing a COGP file.
+For COGP v0.2, geometries in the primary geometry column MUST NOT cross the antimeridian in a way that makes GeoParquet bbox covering unsuitable for spatial pruning. Producers SHOULD split such geometries or use another representation before writing a COGP file.
 
 ### 5.2 Physical ordering
 
@@ -112,11 +121,19 @@ Earlier row groups MUST contain features that are independently meaningful at co
 
 Later row groups MUST add features that are independently meaningful only at finer render resolutions.
 
-Every source feature MUST appear in exactly one row group. Feature geometry and attributes MUST NOT be simplified or aggregated.
+Every source feature MUST appear in exactly one row group. Its primary geometry and attributes MUST NOT be simplified or aggregated. Geometry overview columns MAY contain simplified copies.
 
-Level ordering is defined with respect to the primary geometry column. Non-primary geometry columns, if present, are not constrained by this profile.
+Level ordering is defined with respect to the primary geometry column.
 
 Within each level, features SHOULD be spatially clustered so that row group bounding boxes are tight and spatial pruning by readers is effective.
+
+For LineString and Polygon features, producers SHOULD derive the first visible
+level from simplification at the level's rendering tolerance. A LineString
+SHOULD be deferred while its simplified length does not exceed that tolerance;
+a Polygon SHOULD be deferred while simplification cannot retain a valid
+exterior ring. Such features SHOULD NOT be thinned by assigning their bbox
+centers to density-grid cells; the simplified geometry is the more direct
+signal.
 
 Producers SHOULD spatially sort or pack features within each level before forming row groups. Suitable approaches include, but are not limited to, ordering features by a spatial filling curve such as a Hilbert curve, ordering features by Quadkey or another quadtree-derived key, or using a packed spatial index layout such as STR packing.
 
@@ -151,7 +168,55 @@ Producers SHOULD choose row group sizes so that each level prefix can be fetched
 
 Producers SHOULD avoid placing so many bytes or features in an early row group that the first level is no longer useful as a coarse overview.
 
+When geometry overviews are present, producers SHOULD size row groups using the
+geometry column chunks that rendering readers actually project rather than the
+lossless primary WKB column. A producer MAY use the largest usable overview WKB
+payload as a conservative pre-compression estimate.
+
 This profile does not mandate a specific compressed byte size, feature count, or row group sizing algorithm.
+
+Producers SHOULD derive hierarchy depth from rendering payload rather than a
+fixed number of levels or overview columns. One deterministic approach is to
+evaluate a candidate GSD ladder whose linear resolution halves at every step,
+measure each candidate's simplified WKB prefix, and retain the finest candidate
+whose payload is no more than four times the previously retained payload. If
+the immediately following candidate already exceeds that bound, it is retained
+so progress is guaranteed. Empty candidates are omitted, while the coarsest and
+finest occupied candidates are retained. The factor of four corresponds to the
+area growth produced by halving linear resolution, as in a raster overview
+pyramid.
+
+For this calculation, the simplified WKB prefix at candidate `i` is the sum of
+the WKB sizes, simplified independently at candidate `i`'s tolerance, of every
+feature introduced at or before candidate `i`. Producers SHOULD use the prefix
+maximum of this sequence so that hierarchy selection is monotonic even when a
+particular simplification result is anomalously smaller at a finer tolerance.
+
+### 5.5 Geometry overview columns
+
+Each geometry overview MUST link to one entry in `levels`. Its physical WKB
+column MUST be non-null from row group `0` through the linked level's
+`row_group_end`, inclusive, and MUST be null in every later row group.
+Each entry MUST declare `tolerance_meters` as a positive finite number giving
+the maximum spatial simplification tolerance in meters. This value is
+independent of the linked level: `level` describes completeness, while
+`tolerance_meters` describes geometric precision.
+
+Within one overview column, producers MUST apply one scale-derived spatial
+tolerance consistently to all non-point geometries. Producers MUST derive each
+overview directly from the lossless primary geometry or from an equivalent
+progressive hierarchy; simplification error MUST NOT accumulate by repeatedly
+simplifying the previous overview. Point geometries remain unchanged.
+
+Geometry overview entries MUST be ordered by strictly increasing level index
+and strictly decreasing `tolerance_meters`.
+When `geometry_overviews` is non-empty, its final entry MUST link to the final
+entry in `levels`. This makes the finest overview non-null across the complete
+feature ladder, allowing rendering readers to avoid projecting the lossless
+primary geometry.
+Their columns MUST be nullable WKB geometry columns declared in GeoParquet
+metadata. The primary geometry MUST remain unchanged and non-null wherever the
+source geometry is non-null.
 
 ## 6. Metadata
 
@@ -178,7 +243,7 @@ Readers MUST NOT interpret `cogp` metadata with an unsupported major version as 
 
 ```json
 {
-  "version": "0.1.0",
+  "version": "0.2.0",
   "levels": [
     {
       "row_group_end": 0,
@@ -192,6 +257,11 @@ Readers MUST NOT interpret `cogp` metadata with an unsupported major version as 
       "row_group_end": 12,
       "gsd": 100
     }
+  ],
+  "geometry_overviews": [
+    { "column": "geometry_ovr_0", "level": 0, "tolerance_meters": 250 },
+    { "column": "geometry_ovr_1", "level": 1, "tolerance_meters": 100 },
+    { "column": "geometry_ovr_2", "level": 2, "tolerance_meters": 25 }
   ]
 }
 ```
@@ -204,6 +274,10 @@ Readers MUST NOT interpret `cogp` metadata with an unsupported major version as 
 | `levels`                 |      Yes | Ordered level entries from coarse to fine.                                                                        |
 | `levels[].row_group_end` |      Yes | Inclusive row group index ending this level.                                                                      |
 | `levels[].gsd`           |      Yes | Approximate smallest independently meaningful ground distance represented by this level, in meters.                |
+| `geometry_overviews` | No | Sparse rendering WKB columns ordered from coarse to fine. |
+| `geometry_overviews[].column` | No | Physical nullable WKB column declared in GeoParquet metadata. |
+| `geometry_overviews[].level` | No | Zero-based index into `levels`, defining the non-null boundary. |
+| `geometry_overviews[].tolerance_meters` | No | Positive spatial simplification tolerance in meters. |
 
 ## 7. Reader guidance (non-normative)
 
@@ -238,6 +312,28 @@ For viewport-driven applications, two complementary spatial filters can apply wi
 * **Per-feature bbox filter.** Within a fetched row group, the bbox covering columns can be evaluated as a predicate to skip individual features. This is the standard GeoParquet bbox covering filter and remains fully effective in COGP files.
 
 If the view changes — for example, the user zooms in — the reader fetches only the additional row groups it needs. Because COGP does not duplicate features across levels, previously-read row groups remain valid.
+
+### 7.3 Geometry overview selection
+
+Feature selection and geometry selection are related but independent. A reader
+first selects the row prefix as described in Section 7.1. It then selects the
+first geometry overview, in metadata order, that satisfies both:
+
+```text
+overview.level >= selected_feature_level
+overview.tolerance_meters <= target_gsd
+```
+
+The first condition guarantees that the chosen column is non-null throughout
+the selected row prefix. The second guarantees that its simplification scale is
+no coarser than the requested display scale. If no overview satisfies both
+conditions, a lossless reader selects the primary geometry. A bounded rendering
+reader may instead select the finest overview that covers the prefix, accepting
+its declared simplification tolerance rather than fetching raw WKB. In
+particular, LineString and Polygon streaming readers can use this rule to keep
+the lossless primary column entirely out of their `target_gsd` read path. A
+reader needs to project only the selected physical geometry column and exposes
+it logically under the primary geometry column name.
 
 ## 8. Validation
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -186,11 +186,13 @@ finest occupied candidates are retained. The factor of four corresponds to the
 area growth produced by halving linear resolution, as in a raster overview
 pyramid.
 
-For this calculation, the simplified WKB prefix at candidate `i` is the sum of
-the WKB sizes, simplified independently at candidate `i`'s tolerance, of every
-feature introduced at or before candidate `i`. Producers SHOULD use the prefix
-maximum of this sequence so that hierarchy selection is monotonic even when a
-particular simplification result is anomalously smaller at a finer tolerance.
+For this calculation, the rendering WKB prefix at candidate `i` is the sum of
+the WKB sizes of every feature introduced at or before candidate `i`. Line and
+Polygon WKB is simplified independently at candidate `i`'s tolerance; Point WKB
+is measured from the primary column without simplification. Producers SHOULD
+use the prefix maximum of this sequence so that hierarchy selection is monotonic
+even when a particular simplification result is anomalously smaller at a finer
+tolerance.
 
 ### 5.5 Geometry overview columns
 
@@ -206,7 +208,8 @@ Within one overview column, producers MUST apply one scale-derived spatial
 tolerance consistently to all non-point geometries. Producers MUST derive each
 overview directly from the lossless primary geometry or from an equivalent
 progressive hierarchy; simplification error MUST NOT accumulate by repeatedly
-simplifying the previous overview. Point geometries remain unchanged.
+simplifying the previous overview. Point geometries remain unchanged and SHOULD
+NOT be duplicated into overview columns because no simplification is possible.
 
 Geometry overview entries MUST be ordered by strictly increasing level index
 and strictly decreasing `tolerance_meters`.

--- a/SPEC.md
+++ b/SPEC.md
@@ -45,7 +45,9 @@ COGP's row layout is a **feature-level progressive subset**:
 * a feature's primary geometry is preserved verbatim;
 * features are assigned to the coarsest level at which they become independently renderable as whole features.
 
-Unlike a tile pyramid, COGP does not duplicate rows across levels. Optional geometry overview columns contain simplified rendering copies and are sparse outside the row prefix where they apply.
+Unlike a tile pyramid, COGP does not duplicate rows across levels. Level
+geometry columns may contain simplified rendering copies and are sparse outside
+the row prefixes where they apply.
 
 A reader can choose how many leading row groups to load based on its target rendering resolution.
 
@@ -63,20 +65,17 @@ A logical rendering detail level.
 
 Levels are represented by metadata and row group boundaries. This profile does not require a `level`, `zoom`, or `zoomlevel` column in the data.
 
-### 4.2 Ground sample distance (GSD)
+### 4.2 Ground resolution
 
-`gsd` is the approximate smallest ground distance represented as an independently meaningful unit at this level.
-
-The term is borrowed from raster imagery, where GSD denotes the ground distance represented by one pixel. In COGP it is used by analogy for vector data: the threshold below which features are not represented as independently meaningful at this level.
+`resolution_meters` is the nominal ground resolution for which a level's
+feature prefix and geometry representation are intended to be rendered.
 
 The value is always expressed in meters of ground distance at the geographic location of the features, independent of the CRS or units used by the underlying data. For example, a file in EPSG:4326 (degrees) still expresses this value in meters.
 
-For example, a level with `gsd` equal to `1000` represents independently meaningful units at approximately 1000 meters or larger, while finer units are deferred to later levels.
-
-For feature levels, `gsd` describes the threshold at which whole features
-become independently meaningful. Geometry precision is described separately by
-each overview's `tolerance_meters`; linking an overview to a level defines only
-which feature prefix that column covers.
+For example, a level with `resolution_meters` equal to `1000` contains the
+feature prefix and geometry representation intended for rendering at an
+approximately 1000-meter ground resolution. Finer detail is deferred to later
+levels.
 
 This may apply to deferring features such as:
 
@@ -85,7 +84,9 @@ This may apply to deferring features such as:
 * a small polygon feature that does not form a meaningful rendered shape;
 * a polygon feature too small to form at least a minimal visible area at the target display scale.
 
-This value is rendering-oriented. It does not guarantee positional accuracy, topological validity, or analytical precision.
+This value is rendering-oriented. It is not a measured geometric error or an
+accuracy guarantee, and it does not guarantee positional accuracy, topological
+validity, or analytical precision.
 
 ## 5. Requirements
 
@@ -121,7 +122,9 @@ Earlier row groups MUST contain features that are independently meaningful at co
 
 Later row groups MUST add features that are independently meaningful only at finer render resolutions.
 
-Every source feature MUST appear in exactly one row group. Its primary geometry and attributes MUST NOT be simplified or aggregated. Geometry overview columns MAY contain simplified copies.
+Every source feature MUST appear in exactly one row group. Its primary geometry
+and attributes MUST NOT be simplified or aggregated. Non-primary level geometry
+columns MAY contain simplified copies.
 
 Level ordering is defined with respect to the primary geometry column.
 
@@ -146,7 +149,8 @@ The file-level metadata MUST contain a non-empty ordered list of level entries.
 Each level entry MUST contain:
 
 * `row_group_end`
-* `gsd`
+* `resolution_meters`
+* `geometry_column`
 
 `row_group_end` MUST be a JSON integer satisfying `0 <= row_group_end < num_row_groups`, where `num_row_groups` is the number of Parquet row groups in the file. Row group indices are zero-based.
 
@@ -158,9 +162,13 @@ The row groups belonging to the second and later levels are the row groups after
 
 The final `row_group_end` value MUST equal `num_row_groups - 1`, so that the levels collectively cover every row group in the file.
 
-`gsd` MUST be a positive JSON number.
+`resolution_meters` MUST be a positive finite JSON number.
 
-`gsd` values MUST be strictly monotonically decreasing from coarse to fine levels.
+`resolution_meters` values MUST be strictly monotonically decreasing from coarse to fine levels.
+
+`geometry_column` MUST be the non-empty name of a physical WKB geometry column
+declared in GeoParquet metadata. It defines the geometry representation a
+renderer uses with this level's row-group prefix.
 
 ### 5.4 Progressive access layout
 
@@ -168,58 +176,42 @@ Producers SHOULD choose row group sizes so that each level prefix can be fetched
 
 Producers SHOULD avoid placing so many bytes or features in an early row group that the first level is no longer useful as a coarse overview.
 
-When geometry overviews are present, producers SHOULD size row groups using the
-geometry column chunks that rendering readers actually project rather than the
-lossless primary WKB column. A producer MAY use the largest usable overview WKB
-payload as a conservative pre-compression estimate.
+When simplified level geometry columns are present, producers SHOULD size row
+groups using the geometry column chunks that rendering readers actually project
+rather than the lossless primary WKB column. A producer MAY use the largest
+usable rendering WKB payload as a conservative pre-compression estimate.
 
 This profile does not mandate a specific compressed byte size, feature count, or row group sizing algorithm.
 
-Producers SHOULD derive hierarchy depth from rendering payload rather than a
-fixed number of levels or overview columns. One deterministic approach is to
-evaluate a candidate GSD ladder whose linear resolution halves at every step,
-measure each candidate's simplified WKB prefix, and retain the finest candidate
-whose payload is no more than four times the previously retained payload. If
-the immediately following candidate already exceeds that bound, it is retained
-so progress is guaranteed. Empty candidates are omitted, while the coarsest and
-finest occupied candidates are retained. The factor of four corresponds to the
-area growth produced by halving linear resolution, as in a raster overview
-pyramid.
+Producers SHOULD preserve each requested candidate ground resolution that
+introduces at least one feature. A producer MAY omit candidates to which no
+features are assigned.
 
-For this calculation, the rendering WKB prefix at candidate `i` is the sum of
-the WKB sizes of every feature introduced at or before candidate `i`. Line and
-Polygon WKB is simplified independently at candidate `i`'s tolerance; Point WKB
-is measured from the primary column without simplification. Producers SHOULD
-use the prefix maximum of this sequence so that hierarchy selection is monotonic
-even when a particular simplification result is anomalously smaller at a finer
-tolerance.
+### 5.5 Level geometry columns
 
-### 5.5 Geometry overview columns
+The geometry column named by each level MUST be non-null from row group `0`
+through that level's `row_group_end`, inclusive. When a non-primary geometry
+column is referenced by multiple levels, it MUST be non-null through the
+greatest `row_group_end` of those levels and MUST be null in every later row
+group.
 
-Each geometry overview MUST link to one entry in `levels`. Its physical WKB
-column MUST be non-null from row group `0` through the linked level's
-`row_group_end`, inclusive, and MUST be null in every later row group.
-Each entry MUST declare `tolerance_meters` as a positive finite number giving
-the maximum spatial simplification tolerance in meters. This value is
-independent of the linked level: `level` describes completeness, while
-`tolerance_meters` describes geometric precision.
+Within one level geometry column, producers MUST apply one scale-derived
+spatial tolerance consistently to all non-point geometries. Producers MUST
+derive each simplified representation directly from the lossless primary
+geometry or from an equivalent progressive hierarchy; simplification error MUST
+NOT accumulate by repeatedly simplifying the previous representation. Point
+geometries remain unchanged and SHOULD NOT be duplicated into non-primary level
+geometry columns because no simplification is possible.
+Producers MAY snap retained XY vertices to a grid derived from the level's
+spatial tolerance to improve compression. Such quantization MUST apply only to
+non-primary level geometry columns; the primary geometry remains lossless. Producers SHOULD NOT
+quantize Z or M ordinates unless their units and error bounds are independently
+defined.
 
-Within one overview column, producers MUST apply one scale-derived spatial
-tolerance consistently to all non-point geometries. Producers MUST derive each
-overview directly from the lossless primary geometry or from an equivalent
-progressive hierarchy; simplification error MUST NOT accumulate by repeatedly
-simplifying the previous overview. Point geometries remain unchanged and SHOULD
-NOT be duplicated into overview columns because no simplification is possible.
-
-Geometry overview entries MUST be ordered by strictly increasing level index
-and strictly decreasing `tolerance_meters`.
-When `geometry_overviews` is non-empty, its final entry MUST link to the final
-entry in `levels`. This makes the finest overview non-null across the complete
-feature ladder, allowing rendering readers to avoid projecting the lossless
-primary geometry.
-Their columns MUST be nullable WKB geometry columns declared in GeoParquet
-metadata. The primary geometry MUST remain unchanged and non-null wherever the
-source geometry is non-null.
+Non-primary level geometry columns MUST be nullable WKB geometry columns. The
+primary geometry column MAY be referenced directly, which is appropriate for
+Point data or any level that requires lossless geometry. The primary geometry
+MUST remain unchanged and non-null wherever the source geometry is non-null.
 
 ## 6. Metadata
 
@@ -250,21 +242,19 @@ Readers MUST NOT interpret `cogp` metadata with an unsupported major version as 
   "levels": [
     {
       "row_group_end": 0,
-      "gsd": 1000
+      "resolution_meters": 1000,
+      "geometry_column": "geometry_ovr_0"
     },
     {
       "row_group_end": 3,
-      "gsd": 500
+      "resolution_meters": 500,
+      "geometry_column": "geometry_ovr_1"
     },
     {
       "row_group_end": 12,
-      "gsd": 100
+      "resolution_meters": 100,
+      "geometry_column": "geometry_ovr_2"
     }
-  ],
-  "geometry_overviews": [
-    { "column": "geometry_ovr_0", "level": 0, "tolerance_meters": 250 },
-    { "column": "geometry_ovr_1", "level": 1, "tolerance_meters": 100 },
-    { "column": "geometry_ovr_2", "level": 2, "tolerance_meters": 25 }
   ]
 }
 ```
@@ -276,11 +266,8 @@ Readers MUST NOT interpret `cogp` metadata with an unsupported major version as 
 | `version`              |      Yes | Profile metadata version.                                                                                         |
 | `levels`                 |      Yes | Ordered level entries from coarse to fine.                                                                        |
 | `levels[].row_group_end` |      Yes | Inclusive row group index ending this level.                                                                      |
-| `levels[].gsd`           |      Yes | Approximate smallest independently meaningful ground distance represented by this level, in meters.                |
-| `geometry_overviews` | No | Sparse rendering WKB columns ordered from coarse to fine. |
-| `geometry_overviews[].column` | No | Physical nullable WKB column declared in GeoParquet metadata. |
-| `geometry_overviews[].level` | No | Zero-based index into `levels`, defining the non-null boundary. |
-| `geometry_overviews[].tolerance_meters` | No | Positive spatial simplification tolerance in meters. |
+| `levels[].resolution_meters` | Yes | Nominal ground resolution for which the level is intended, in meters. |
+| `levels[].geometry_column` | Yes | Physical WKB geometry column to render for this level. |
 
 ## 7. Reader guidance (non-normative)
 
@@ -290,10 +277,14 @@ COGP metadata describes available levels but does not prescribe how a reader use
 
 A renderer can base the choice of level on zoom level, map scale, screen-space error, or any application-specific budget for bytes, features, or latency.
 
-One common strategy is to derive a target ground sample distance from the current display scale and select the finest level whose `gsd` is still coarser than or equal to that target. Because `levels` are ordered from coarse to fine and `gsd` values strictly decrease, this is the last level satisfying:
+One common strategy is to derive a target ground resolution from the current
+display scale and select the finest level whose `resolution_meters` is still
+coarser than or equal to that target. Because `levels` are ordered from coarse
+to fine and `resolution_meters` values strictly decrease, this is the last
+level satisfying:
 
 ```text
-gsd >= target_gsd
+resolution_meters >= target_resolution_meters
 ```
 
 If no level satisfies this condition, the target resolution is coarser than the coarsest level in the file, and the reader can select the first level.
@@ -316,27 +307,16 @@ For viewport-driven applications, two complementary spatial filters can apply wi
 
 If the view changes — for example, the user zooms in — the reader fetches only the additional row groups it needs. Because COGP does not duplicate features across levels, previously-read row groups remain valid.
 
-### 7.3 Geometry overview selection
+### 7.3 Geometry column selection
 
-Feature selection and geometry selection are related but independent. A reader
-first selects the row prefix as described in Section 7.1. It then selects the
-first geometry overview, in metadata order, that satisfies both:
+After selecting a level, a rendering reader projects that level's
+`geometry_column`. The column is guaranteed to be non-null throughout the
+selected row prefix, so no second metadata search or precision comparison is
+needed. The reader may expose the selected physical column logically under the
+primary geometry column name.
 
-```text
-overview.level >= selected_feature_level
-overview.tolerance_meters <= target_gsd
-```
-
-The first condition guarantees that the chosen column is non-null throughout
-the selected row prefix. The second guarantees that its simplification scale is
-no coarser than the requested display scale. If no overview satisfies both
-conditions, a lossless reader selects the primary geometry. A bounded rendering
-reader may instead select the finest overview that covers the prefix, accepting
-its declared simplification tolerance rather than fetching raw WKB. In
-particular, LineString and Polygon streaming readers can use this rule to keep
-the lossless primary column entirely out of their `target_gsd` read path. A
-reader needs to project only the selected physical geometry column and exposes
-it logically under the primary geometry column name.
+A reader that requires lossless geometry explicitly projects the GeoParquet
+primary geometry column instead of the level geometry column.
 
 ## 8. Validation
 

--- a/cogp-js/README.md
+++ b/cogp-js/README.md
@@ -3,7 +3,7 @@
 TypeScript reader for the [Cloud Optimized GeoParquet Profile
 (COGP)](https://github.com/Kanahiro/cloud-optimized-geoparquet). It reads COGP
 metadata and fetches only the Parquet ranges needed for a requested geographic
-area and ground sample distance. Bbox reads use covering-column statistics to
+area and target ground resolution. Bbox reads use covering-column statistics to
 prune row groups, then apply an exact per-feature bbox filter to the surviving
 rows.
 
@@ -47,14 +47,11 @@ pnpm --filter cogp-demo build
 ```
 
 The public entry point exports `CogpReader`, metadata parsing helpers,
-`selectLevelByGsd`, `selectGeometryColumnByGsd`, and their associated
-TypeScript types. `readRows({ targetGsd })` projects a single sufficiently
-precise WKB column and returns its decoded value under the primary column name.
-For Polygon-only data, this streaming path never projects the lossless primary
-WKB column when overviews exist: requests finer than the available overviews
-stay on the finest complete overview. A file with no overviews falls back to
-the primary raw WKB column. Omit `targetGsd` when lossless primary geometry is
-required regardless of available overviews.
+`selectLevelByResolution` and the associated TypeScript types.
+`readRows({ targetResolutionMeters })` selects one self-contained level,
+projects its declared `geometry_column`, and returns the decoded value under
+the primary column name. Omit `targetResolutionMeters` when lossless primary
+geometry is required.
 
 For interactive maps, keep viewport projections narrow and fetch full
 properties only for selected features. `rowIndexColumn` adds a stable source
@@ -64,7 +61,7 @@ that one row:
 ```ts
 const rows = await reader.readRows({
   bbox,
-  targetGsd,
+  targetResolutionMeters,
   columns: [reader.primaryGeometryColumn],
   rowIndexColumn: '__row',
 });

--- a/cogp-js/README.md
+++ b/cogp-js/README.md
@@ -7,10 +7,11 @@ area and ground sample distance. Bbox reads use covering-column statistics to
 prune row groups, then apply an exact per-feature bbox filter to the surviving
 rows.
 
-Remote reads coalesce nearby concurrent byte ranges by default. This reduces
-HTTP request count while bounding extra transfer to a
-128 KiB gap and total fetched bytes to 1.25× the uniquely requested bytes. Tune
-or disable it when opening:
+Remote reads coalesce nearby concurrent byte ranges by default. Coalescing
+bounds extra transfer to a 128 KiB gap and 1.25× the uniquely requested bytes.
+Exact requested slices are retained in a 128 MiB least-recently-used cache, so
+slightly overlapping viewport reads do not depend on HTTP `206 Partial
+Content` cache behavior. Tune or disable either layer when opening:
 
 ```ts
 await CogpReader.open(url, {
@@ -18,9 +19,16 @@ await CogpReader.open(url, {
     maxGapBytes: 64 * 1024,
     maxOverfetchRatio: 1.25,
   },
+  rangeCache: { maxBytes: 64 * 1024 * 1024 },
 });
 await CogpReader.open(url, { rangeCoalescing: false });
+await CogpReader.open(url, { rangeCache: false });
 ```
+
+Explicit HTTP caching is still useful across page loads and reader instances.
+Use stable, versioned object URLs before assigning a long `max-age` or
+`immutable`; an unversioned URL that is overwritten can otherwise serve stale
+Parquet metadata and ranges.
 
 ## Development
 
@@ -39,4 +47,28 @@ pnpm --filter cogp-demo build
 ```
 
 The public entry point exports `CogpReader`, metadata parsing helpers,
-`selectLevelByGsd`, and their associated TypeScript types.
+`selectLevelByGsd`, `selectGeometryColumnByGsd`, and their associated
+TypeScript types. `readRows({ targetGsd })` projects a single sufficiently
+precise WKB column and returns its decoded value under the primary column name.
+For Polygon-only data, this streaming path never projects the lossless primary
+WKB column when overviews exist: requests finer than the available overviews
+stay on the finest complete overview. A file with no overviews falls back to
+the primary raw WKB column. Omit `targetGsd` when lossless primary geometry is
+required regardless of available overviews.
+
+For interactive maps, keep viewport projections narrow and fetch full
+properties only for selected features. `rowIndexColumn` adds a stable source
+row index to the lightweight result; `readRow` then reads chosen columns for
+that one row:
+
+```ts
+const rows = await reader.readRows({
+  bbox,
+  targetGsd,
+  columns: [reader.primaryGeometryColumn],
+  rowIndexColumn: '__row',
+});
+const properties = await reader.readRow(rows[0].__row as number, {
+  columns: ['name', 'class'],
+});
+```

--- a/cogp-js/demo/src/cogp-types.ts
+++ b/cogp-js/demo/src/cogp-types.ts
@@ -5,7 +5,8 @@ export interface MetadataSummary {
   num_row_groups: number;
   levels: Array<{
     i: number;
-    gsd: number;
+    resolution_meters: number;
+    geometry_column: string;
     row_group_end: number;
   }>;
   crs: unknown;
@@ -34,7 +35,7 @@ export interface FeaturePropertiesResult {
 
 export type WorkerRequest =
   | { type: 'open'; url: string }
-  | { type: 'readViewport'; url: string; bbox: ViewportBbox; targetGsd: number }
+  | { type: 'readViewport'; url: string; bbox: ViewportBbox; targetResolutionMeters: number }
   | { type: 'readProperties'; url: string; rowIndex: number };
 
 export interface WorkerEnvelope {

--- a/cogp-js/demo/src/cogp-types.ts
+++ b/cogp-js/demo/src/cogp-types.ts
@@ -28,9 +28,14 @@ export interface ViewportResult {
   status: string;
 }
 
+export interface FeaturePropertiesResult {
+  properties: Record<string, unknown>;
+}
+
 export type WorkerRequest =
   | { type: 'open'; url: string }
-  | { type: 'readViewport'; url: string; bbox: ViewportBbox; targetGsd: number };
+  | { type: 'readViewport'; url: string; bbox: ViewportBbox; targetGsd: number }
+  | { type: 'readProperties'; url: string; rowIndex: number };
 
 export interface WorkerEnvelope {
   id: number;
@@ -38,5 +43,5 @@ export interface WorkerEnvelope {
 }
 
 export type WorkerResponse =
-  | { id: number; ok: true; result: OpenResult | ViewportResult }
+  | { id: number; ok: true; result: OpenResult | ViewportResult | FeaturePropertiesResult }
   | { id: number; ok: false; error: string };

--- a/cogp-js/demo/src/cogp-worker.ts
+++ b/cogp-js/demo/src/cogp-worker.ts
@@ -57,21 +57,21 @@ async function openDataset(url: string): Promise<OpenResult> {
 async function readViewport(
   url: string,
   bbox: ViewportBbox,
-  targetGsd: number,
+  targetResolutionMeters: number,
 ): Promise<ViewportResult> {
   const ds = active;
   if (!ds || ds.url !== url) {
     return { data: { type: 'FeatureCollection', features: [] }, status: '' };
   }
   const geomColumn = ds.reader.primaryGeometryColumn;
-  const maxLevel = ds.reader.selectLevel(targetGsd);
-  const selectedGeometry = ds.reader.selectGeometryColumn(targetGsd, maxLevel);
+  const maxLevel = ds.reader.selectLevel(targetResolutionMeters);
+  const selectedGeometry = ds.reader.selectGeometryColumn(targetResolutionMeters, maxLevel);
   const bytesBefore = ds.transfers.bytes;
   const requestsBefore = ds.transfers.requests;
   const rows = await ds.reader.readRows({
     bbox,
     maxLevel,
-    targetGsd,
+    targetResolutionMeters,
     columns: [geomColumn],
     maxRows: VIEWPORT_MAX_ROWS,
     maxRowWkbBytes: VIEWPORT_MAX_ROW_WKB_BYTES,
@@ -98,7 +98,7 @@ async function readViewport(
   const transferRequests = ds.transfers.requests - requestsBefore;
   return {
     data: { type: 'FeatureCollection', features },
-    status: `Loaded ${features.length} features at ${formatGsd(targetGsd)}/px (level <= ${maxLevel}, geometry: ${selectedGeometry}, transfer: ${formatBytes(transferredBytes)} / ${transferRequests} requests, total: ${formatBytes(ds.transfers.bytes)}). Updates: ${ds.servedViewports}.`,
+    status: `Loaded ${features.length} features at ${formatResolution(targetResolutionMeters)}/px (level <= ${maxLevel}, geometry: ${selectedGeometry}, transfer: ${formatBytes(transferredBytes)} / ${transferRequests} requests, total: ${formatBytes(ds.transfers.bytes)}). Updates: ${ds.servedViewports}.`,
   };
 }
 
@@ -135,7 +135,8 @@ function metadataSummary(reader: CogpReader): MetadataSummary {
     num_row_groups: reader.numRowGroups,
     levels: reader.levels.map((l, i) => ({
       i,
-      gsd: l.gsd,
+      resolution_meters: l.resolution_meters,
+      geometry_column: l.geometry_column,
       row_group_end: l.row_group_end,
     })),
     crs: reader.geo.columns[reader.primaryGeometryColumn]?.crs ?? null,
@@ -191,10 +192,10 @@ function coerceForGeoJson(value: unknown): unknown {
   return value;
 }
 
-function formatGsd(gsdMeters: number): string {
-  if (gsdMeters >= 1000) return `${(gsdMeters / 1000).toFixed(1)} km`;
-  if (gsdMeters >= 1) return `${gsdMeters.toFixed(1)} m`;
-  return `${(gsdMeters * 100).toFixed(1)} cm`;
+function formatResolution(resolutionMeters: number): string {
+  if (resolutionMeters >= 1000) return `${(resolutionMeters / 1000).toFixed(1)} km`;
+  if (resolutionMeters >= 1) return `${resolutionMeters.toFixed(1)} m`;
+  return `${(resolutionMeters * 100).toFixed(1)} cm`;
 }
 
 function formatBytes(bytes: number): string {
@@ -210,7 +211,7 @@ self.onmessage = async (e: MessageEvent<WorkerEnvelope>) => {
     if (payload.type === 'open') {
       result = await openDataset(payload.url);
     } else if (payload.type === 'readViewport') {
-      result = await readViewport(payload.url, payload.bbox, payload.targetGsd);
+      result = await readViewport(payload.url, payload.bbox, payload.targetResolutionMeters);
     } else {
       result = await readProperties(payload.url, payload.rowIndex);
     }

--- a/cogp-js/demo/src/cogp-worker.ts
+++ b/cogp-js/demo/src/cogp-worker.ts
@@ -3,6 +3,7 @@ import { CogpReader } from 'cogp';
 import type { Feature, Geometry } from 'geojson';
 
 import type {
+  FeaturePropertiesResult,
   MetadataSummary,
   OpenResult,
   ViewportBbox,
@@ -13,13 +14,21 @@ import type {
 
 const VIEWPORT_MAX_ROWS = 50_000;
 const VIEWPORT_MAX_ROW_WKB_BYTES = 20_000_000;
+const VIEWPORT_ROW_INDEX = '__cogp_row_index';
 
 interface ActiveDataset {
   url: string;
   reader: CogpReader;
   dataBbox: [[number, number], [number, number]] | null;
   bboxStructTop: string | null;
+  detailColumns: string[];
+  transfers: TransferStats;
   servedViewports: number;
+}
+
+interface TransferStats {
+  bytes: number;
+  requests: number;
 }
 
 let active: ActiveDataset | null = null;
@@ -27,7 +36,8 @@ let latestUrl = '';
 
 async function openDataset(url: string): Promise<OpenResult> {
   latestUrl = url;
-  const reader = await CogpReader.open(url);
+  const transfers: TransferStats = { bytes: 0, requests: 0 };
+  const reader = await CogpReader.open(url, { fetch: trackingFetch(transfers) });
   if (latestUrl !== url) throw new Error('Dataset open was superseded');
 
   const dataBbox = computeDataBbox(reader);
@@ -36,6 +46,8 @@ async function openDataset(url: string): Promise<OpenResult> {
     reader,
     dataBbox,
     bboxStructTop: bboxStructTopColumn(reader),
+    detailColumns: detailColumnNames(reader),
+    transfers,
     servedViewports: 0,
   };
 
@@ -53,30 +65,67 @@ async function readViewport(
   }
   const geomColumn = ds.reader.primaryGeometryColumn;
   const maxLevel = ds.reader.selectLevel(targetGsd);
+  const selectedGeometry = ds.reader.selectGeometryColumn(targetGsd, maxLevel);
+  const bytesBefore = ds.transfers.bytes;
+  const requestsBefore = ds.transfers.requests;
   const rows = await ds.reader.readRows({
     bbox,
     maxLevel,
+    targetGsd,
+    columns: [geomColumn],
     maxRows: VIEWPORT_MAX_ROWS,
     maxRowWkbBytes: VIEWPORT_MAX_ROW_WKB_BYTES,
+    rowIndexColumn: VIEWPORT_ROW_INDEX,
   });
 
   const features: Feature[] = [];
-  const skip = new Set<string>([geomColumn]);
+  const skip = new Set<string>([geomColumn, VIEWPORT_ROW_INDEX]);
   if (ds.bboxStructTop) skip.add(ds.bboxStructTop);
   for (const row of rows) {
     const geometry = row[geomColumn] as Geometry | null | undefined;
     if (!geometry) continue;
+    const rowIndex = row[VIEWPORT_ROW_INDEX];
+    if (typeof rowIndex !== 'number') continue;
     const properties: Record<string, unknown> = {};
     for (const [key, value] of Object.entries(row)) {
       if (skip.has(key)) continue;
       properties[key] = coerceForGeoJson(value);
     }
-    features.push({ type: 'Feature', geometry, properties });
+    features.push({ type: 'Feature', id: rowIndex, geometry, properties });
   }
   ds.servedViewports += 1;
+  const transferredBytes = ds.transfers.bytes - bytesBefore;
+  const transferRequests = ds.transfers.requests - requestsBefore;
   return {
     data: { type: 'FeatureCollection', features },
-    status: `Loaded ${features.length} features at ${formatGsd(targetGsd)}/px (level <= ${maxLevel}). Updates: ${ds.servedViewports}.`,
+    status: `Loaded ${features.length} features at ${formatGsd(targetGsd)}/px (level <= ${maxLevel}, geometry: ${selectedGeometry}, transfer: ${formatBytes(transferredBytes)} / ${transferRequests} requests, total: ${formatBytes(ds.transfers.bytes)}). Updates: ${ds.servedViewports}.`,
+  };
+}
+
+async function readProperties(url: string, rowIndex: number): Promise<FeaturePropertiesResult> {
+  const ds = active;
+  if (!ds || ds.url !== url || ds.detailColumns.length === 0) {
+    return { properties: {} };
+  }
+  const row = await ds.reader.readRow(rowIndex, { columns: ds.detailColumns });
+  if (!row) return { properties: {} };
+  const properties: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(row)) {
+    properties[key] = coerceForGeoJson(value);
+  }
+  return { properties };
+}
+
+function trackingFetch(stats: TransferStats): typeof fetch {
+  return async (input, init) => {
+    const response = await fetch(input, init);
+    const method = input instanceof Request ? input.method : (init?.method ?? 'GET');
+    if (method.toUpperCase() !== 'HEAD') {
+      const contentLength = Number(response.headers.get('content-length'));
+      if (Number.isFinite(contentLength) && contentLength >= 0) stats.bytes += contentLength;
+      stats.requests += 1;
+    }
+    return response;
   };
 }
 
@@ -96,6 +145,18 @@ function metadataSummary(reader: CogpReader): MetadataSummary {
 function bboxStructTopColumn(reader: CogpReader): string | null {
   const path = reader.geo.columns[reader.primaryGeometryColumn]?.covering?.bbox?.xmin;
   return path?.[0] ?? null;
+}
+
+function detailColumnNames(reader: CogpReader): string[] {
+  const geometryColumns = new Set(Object.keys(reader.geo.columns));
+  const bboxColumn = bboxStructTopColumn(reader);
+  return reader.columnNames.filter(
+    (column) =>
+      !geometryColumns.has(column) &&
+      column !== bboxColumn &&
+      column !== 'bbox' &&
+      !column.endsWith('_bbox'),
+  );
 }
 
 function computeDataBbox(reader: CogpReader): [[number, number], [number, number]] | null {
@@ -136,14 +197,22 @@ function formatGsd(gsdMeters: number): string {
   return `${(gsdMeters * 100).toFixed(1)} cm`;
 }
 
+function formatBytes(bytes: number): string {
+  if (bytes >= 1024 * 1024) return `${(bytes / (1024 * 1024)).toFixed(1)} MiB`;
+  if (bytes >= 1024) return `${(bytes / 1024).toFixed(1)} KiB`;
+  return `${bytes} B`;
+}
+
 self.onmessage = async (e: MessageEvent<WorkerEnvelope>) => {
   const { id, payload } = e.data;
   try {
-    let result: OpenResult | ViewportResult;
+    let result: OpenResult | ViewportResult | FeaturePropertiesResult;
     if (payload.type === 'open') {
       result = await openDataset(payload.url);
-    } else {
+    } else if (payload.type === 'readViewport') {
       result = await readViewport(payload.url, payload.bbox, payload.targetGsd);
+    } else {
+      result = await readProperties(payload.url, payload.rowIndex);
     }
     const response: WorkerResponse = { id, ok: true, result };
     self.postMessage(response);

--- a/cogp-js/demo/src/dataset-service.ts
+++ b/cogp-js/demo/src/dataset-service.ts
@@ -47,9 +47,9 @@ export function openDataset(url: string): Promise<OpenResult> {
 export function readViewport(
   url: string,
   bbox: ViewportBbox,
-  targetGsd: number,
+  targetResolutionMeters: number,
 ): Promise<ViewportResult> {
-  return call<ViewportResult>({ type: 'readViewport', url, bbox, targetGsd });
+  return call<ViewportResult>({ type: 'readViewport', url, bbox, targetResolutionMeters });
 }
 
 export function readFeatureProperties(

--- a/cogp-js/demo/src/dataset-service.ts
+++ b/cogp-js/demo/src/dataset-service.ts
@@ -1,4 +1,5 @@
 import type {
+  FeaturePropertiesResult,
   OpenResult,
   ViewportBbox,
   ViewportResult,
@@ -6,7 +7,12 @@ import type {
   WorkerResponse,
 } from './cogp-types';
 
-export type { MetadataSummary, OpenResult, ViewportResult } from './cogp-types';
+export type {
+  FeaturePropertiesResult,
+  MetadataSummary,
+  OpenResult,
+  ViewportResult,
+} from './cogp-types';
 
 const worker = new Worker(new URL('./cogp-worker.ts', import.meta.url), { type: 'module' });
 
@@ -44,4 +50,11 @@ export function readViewport(
   targetGsd: number,
 ): Promise<ViewportResult> {
   return call<ViewportResult>({ type: 'readViewport', url, bbox, targetGsd });
+}
+
+export function readFeatureProperties(
+  url: string,
+  rowIndex: number,
+): Promise<FeaturePropertiesResult> {
+  return call<FeaturePropertiesResult>({ type: 'readProperties', url, rowIndex });
 }

--- a/cogp-js/demo/src/main.ts
+++ b/cogp-js/demo/src/main.ts
@@ -3,12 +3,12 @@ import type { FeatureCollection } from 'geojson';
 
 import {
   openDataset as openCogpDataset,
+  readFeatureProperties,
   readViewport,
   type MetadataSummary,
 } from './dataset-service';
 
 const COGP_SOURCE_ID = 'cogp';
-const VIEWPORT_REFRESH_INTERVAL_MS = 150;
 
 const map = new maplibregl.Map({
   container: 'map',
@@ -35,14 +35,30 @@ map.addControl(new maplibregl.ScaleControl({ unit: 'metric' }), 'bottom-left');
 
 const COGP_INTERACTIVE_LAYERS = ['cogp-fill', 'cogp-line', 'cogp-point'];
 
-map.on('click', (e) => {
+map.on('click', async (e) => {
   const features = map.queryRenderedFeatures(e.point, { layers: COGP_INTERACTIVE_LAYERS });
   const feature = features[0];
   if (!feature) return;
-  new maplibregl.Popup({ maxWidth: '360px' })
+  const ds = active;
+  const rowIndex = Number(feature.id);
+  const popup = new maplibregl.Popup({ maxWidth: '360px' })
     .setLngLat(e.lngLat)
-    .setHTML(renderPropertiesHtml(feature.properties))
+    .setHTML('<div class="cogp-popup"><em>Loading properties…</em></div>')
     .addTo(map);
+  if (!ds || !Number.isSafeInteger(rowIndex)) {
+    popup.setHTML(renderPropertiesHtml(feature.properties));
+    return;
+  }
+  try {
+    const { properties } = await readFeatureProperties(ds.url, rowIndex);
+    if (popup.isOpen()) popup.setHTML(renderPropertiesHtml(properties));
+  } catch (err) {
+    if (popup.isOpen()) {
+      popup.setHTML(
+        `<div class="cogp-popup"><em>Failed to load properties: ${escapeHtml((err as Error).message)}</em></div>`,
+      );
+    }
+  }
 });
 
 for (const layerId of COGP_INTERACTIVE_LAYERS) {
@@ -94,11 +110,12 @@ map.on('load', () => {
   if (active) installCogpSource();
 });
 
-map.on('move', () => {
-  if (active) {
-    viewportToken += 1;
-    requestViewportRefresh();
-  }
+map.on('movestart', () => {
+  if (active) viewportToken += 1;
+});
+
+map.on('moveend', () => {
+  if (active) requestViewportRefresh();
 });
 
 function installCogpSource(): void {
@@ -144,7 +161,7 @@ function installCogpSource(): void {
   });
 
   viewportToken += 1;
-  requestViewportRefresh(true);
+  requestViewportRefresh();
 }
 
 function removeCogpLayersAndSource(): void {
@@ -159,38 +176,23 @@ function emptyFC(): FeatureCollection {
 }
 
 let viewportToken = 0;
-let viewportRefreshTimer: number | null = null;
 let viewportRefreshInFlight = false;
 let viewportRefreshRequested = false;
-let lastViewportRefreshStartedAt = -Infinity;
 
-function requestViewportRefresh(immediate = false): void {
+function requestViewportRefresh(): void {
   viewportRefreshRequested = true;
-  if (viewportRefreshInFlight) return;
-
-  if (viewportRefreshTimer !== null) {
-    if (!immediate) return;
-    clearTimeout(viewportRefreshTimer);
-  }
-
-  const elapsed = performance.now() - lastViewportRefreshStartedAt;
-  const delay = immediate ? 0 : Math.max(0, VIEWPORT_REFRESH_INTERVAL_MS - elapsed);
-  viewportRefreshTimer = window.setTimeout(() => {
-    viewportRefreshTimer = null;
-    void runViewportRefresh();
-  }, delay);
+  if (!viewportRefreshInFlight && !map.isMoving()) void runViewportRefresh();
 }
 
 async function runViewportRefresh(): Promise<void> {
   if (!viewportRefreshRequested || viewportRefreshInFlight) return;
   viewportRefreshRequested = false;
   viewportRefreshInFlight = true;
-  lastViewportRefreshStartedAt = performance.now();
   try {
     await refreshViewport();
   } finally {
     viewportRefreshInFlight = false;
-    if (viewportRefreshRequested) requestViewportRefresh();
+    if (viewportRefreshRequested && !map.isMoving()) void runViewportRefresh();
   }
 }
 

--- a/cogp-js/src/coalescing-buffer.ts
+++ b/cogp-js/src/coalescing-buffer.ts
@@ -34,7 +34,9 @@ const DEFAULT_MAX_OVERFETCH_RATIO = 1.25;
  * group. Waiting until the current microtask finishes exposes that batch
  * without adding a timer delay. Nearby slices are fetched as one ordinary HTTP
  * Range and split back into exact per-caller buffers. The gap limit makes the
- * request-count/extra-byte tradeoff explicit and bounded.
+ * request-count/extra-byte tradeoff explicit and bounded. Completed ranges are
+ * not retained here. A correctly configured HTTP cache may reuse compatible
+ * responses, but differently shaped partial ranges are not assumed reusable.
  */
 export function coalescingAsyncBuffer(
   source: AsyncBufferLike,
@@ -131,7 +133,10 @@ function makeRuns(
   return runs;
 }
 
-async function fetchRun(source: AsyncBufferLike, run: SliceRun): Promise<void> {
+async function fetchRun(
+  source: AsyncBufferLike,
+  run: SliceRun,
+): Promise<void> {
   try {
     const buffer = await source.slice(run.start, run.end);
     const expected = run.end - run.start;

--- a/cogp-js/src/index.ts
+++ b/cogp-js/src/index.ts
@@ -3,8 +3,14 @@ export type {
   BboxInput,
   OpenOptions,
   ReadOptions,
+  ReadRowOptions,
 } from './reader.js';
 export type { RangeCoalescingOptions } from './coalescing-buffer.js';
+export {
+  DEFAULT_RANGE_CACHE_MAX_BYTES,
+  lruCachingAsyncBuffer,
+} from './range-cache.js';
+export type { RangeCacheOptions } from './range-cache.js';
 
 export {
   COGP_METADATA_KEY,
@@ -21,9 +27,10 @@ export type {
   Covering,
   GeoColumn,
   GeoMeta,
+  GeometryOverview,
   Level,
 } from './meta.js';
 
-export { selectLevelByGsd } from './level.js';
+export { selectGeometryColumnByGsd, selectLevelByGsd } from './level.js';
 
 export type { Bbox } from './bbox.js';

--- a/cogp-js/src/index.ts
+++ b/cogp-js/src/index.ts
@@ -27,10 +27,9 @@ export type {
   Covering,
   GeoColumn,
   GeoMeta,
-  GeometryOverview,
   Level,
 } from './meta.js';
 
-export { selectGeometryColumnByGsd, selectLevelByGsd } from './level.js';
+export { selectLevelByResolution } from './level.js';
 
 export type { Bbox } from './bbox.js';

--- a/cogp-js/src/level.ts
+++ b/cogp-js/src/level.ts
@@ -1,4 +1,4 @@
-import type { Level } from './meta.js';
+import type { GeometryOverview, Level } from './meta.js';
 
 // SPEC §7: pick the last level whose gsd >= target_gsd.
 // If no level satisfies that (target is coarser than the coarsest available),
@@ -13,4 +13,37 @@ export function selectLevelByGsd(levels: readonly Level[], targetGsd: number): n
     else break;
   }
   return chosen === -1 ? 0 : chosen;
+}
+
+/**
+ * Select one physical geometry column that is precise enough for `targetGsd`
+ * and complete through `minimumLevel`. Callers doing lossy streaming may keep
+ * the result on the finest complete overview instead of projecting raw WKB.
+ */
+export function selectGeometryColumnByGsd(
+  overviews: readonly GeometryOverview[],
+  targetGsd: number,
+  minimumLevel: number,
+  primaryColumn: string,
+  fallbackToFinestOverview = false,
+): string {
+  // The primary column is the only representation available in a valid COGP
+  // file without overviews. In particular, the bounded Line/Polygon policy
+  // must not turn an optional optimization into a requirement.
+  if (overviews.length === 0) return primaryColumn;
+
+  const precise = overviews.find((overview) =>
+    overview.level >= minimumLevel && overview.tolerance_meters <= targetGsd
+  );
+  if (precise) return precise.column;
+  if (fallbackToFinestOverview) {
+    for (let index = overviews.length - 1; index >= 0; index--) {
+      const overview = overviews[index]!;
+      if (overview.level >= minimumLevel) return overview.column;
+    }
+    throw new Error(
+      `bounded rendering requires a geometry overview complete through level ${minimumLevel}`,
+    );
+  }
+  return primaryColumn;
 }

--- a/cogp-js/src/level.ts
+++ b/cogp-js/src/level.ts
@@ -1,49 +1,18 @@
-import type { GeometryOverview, Level } from './meta.js';
+import type { Level } from './meta.js';
 
-// SPEC §7: pick the last level whose gsd >= target_gsd.
-// If no level satisfies that (target is coarser than the coarsest available),
-// fall back to the first (coarsest) level.
-export function selectLevelByGsd(levels: readonly Level[], targetGsd: number): number {
+// SPEC §7: pick the last level whose nominal ground resolution is at least
+// the target. If none satisfies that, use the coarsest available level.
+export function selectLevelByResolution(
+  levels: readonly Level[],
+  targetResolutionMeters: number,
+): number {
   if (levels.length === 0) {
     throw new Error('cogp metadata has no levels');
   }
   let chosen = -1;
-  for (let i = 0; i < levels.length; i++) {
-    if (levels[i]!.gsd >= targetGsd) chosen = i;
+  for (let index = 0; index < levels.length; index++) {
+    if (levels[index]!.resolution_meters >= targetResolutionMeters) chosen = index;
     else break;
   }
   return chosen === -1 ? 0 : chosen;
-}
-
-/**
- * Select one physical geometry column that is precise enough for `targetGsd`
- * and complete through `minimumLevel`. Callers doing lossy streaming may keep
- * the result on the finest complete overview instead of projecting raw WKB.
- */
-export function selectGeometryColumnByGsd(
-  overviews: readonly GeometryOverview[],
-  targetGsd: number,
-  minimumLevel: number,
-  primaryColumn: string,
-  fallbackToFinestOverview = false,
-): string {
-  // The primary column is the only representation available in a valid COGP
-  // file without overviews. In particular, the bounded Line/Polygon policy
-  // must not turn an optional optimization into a requirement.
-  if (overviews.length === 0) return primaryColumn;
-
-  const precise = overviews.find((overview) =>
-    overview.level >= minimumLevel && overview.tolerance_meters <= targetGsd
-  );
-  if (precise) return precise.column;
-  if (fallbackToFinestOverview) {
-    for (let index = overviews.length - 1; index >= 0; index--) {
-      const overview = overviews[index]!;
-      if (overview.level >= minimumLevel) return overview.column;
-    }
-    throw new Error(
-      `bounded rendering requires a geometry overview complete through level ${minimumLevel}`,
-    );
-  }
-  return primaryColumn;
 }

--- a/cogp-js/src/meta.ts
+++ b/cogp-js/src/meta.ts
@@ -3,15 +3,8 @@ export const GEO_METADATA_KEY = 'geo';
 
 export interface Level {
   row_group_end: number;
-  gsd: number;
-}
-
-export interface GeometryOverview {
-  column: string;
-  /** Index into `CogpMeta.levels`; supplies the non-null boundary. */
-  level: number;
-  /** Maximum spatial simplification error in meters. */
-  tolerance_meters: number;
+  resolution_meters: number;
+  geometry_column: string;
 }
 
 export interface CogpGenerator {
@@ -22,7 +15,6 @@ export interface CogpGenerator {
 export interface CogpMeta {
   version: string;
   levels: Level[];
-  geometry_overviews?: GeometryOverview[];
   generator?: CogpGenerator;
   [extra: string]: unknown;
 }
@@ -76,45 +68,25 @@ export function parseCogpMeta(json: string): CogpMeta {
   if (!Array.isArray(parsed.levels) || parsed.levels.length === 0) {
     throw new Error('cogp metadata: `levels` must be a non-empty array');
   }
-  if (parsed.geometry_overviews !== undefined) {
-    if (!Array.isArray(parsed.geometry_overviews)) {
-      throw new Error('cogp metadata: `geometry_overviews` must be an array');
+  let previousResolution = Infinity;
+  let previousRowGroupEnd = -1;
+  for (const [index, level] of parsed.levels.entries()) {
+    if (!Number.isInteger(level.row_group_end) || level.row_group_end < 0) {
+      throw new Error(`cogp metadata: levels[${index}].row_group_end must be a non-negative integer`);
     }
-    let previousLevel = -1;
-    let previousTolerance = Infinity;
-    const columns = new Set<string>();
-    for (const [index, overview] of parsed.geometry_overviews.entries()) {
-      if (typeof overview.column !== 'string' || overview.column.length === 0) {
-        throw new Error(
-          `cogp metadata: geometry_overviews[${index}].column must be a non-empty string`,
-        );
-      }
-      if (columns.has(overview.column)) {
-        throw new Error(`cogp metadata: duplicate geometry overview column \`${overview.column}\``);
-      }
-      columns.add(overview.column);
-      if (!Number.isInteger(overview.level) || overview.level < 0 || overview.level >= parsed.levels.length) {
-        throw new Error(`cogp metadata: geometry_overviews[${index}].level is out of range`);
-      }
-      if (overview.level <= previousLevel) {
-        throw new Error('cogp metadata: geometry overview levels must be strictly increasing');
-      }
-      previousLevel = overview.level;
-      if (!Number.isFinite(overview.tolerance_meters) || overview.tolerance_meters <= 0) {
-        throw new Error(
-          `cogp metadata: geometry_overviews[${index}].tolerance_meters must be positive and finite`,
-        );
-      }
-      if (overview.tolerance_meters >= previousTolerance) {
-        throw new Error(
-          'cogp metadata: geometry overview tolerances must be strictly decreasing',
-        );
-      }
-      previousTolerance = overview.tolerance_meters;
+    if (level.row_group_end <= previousRowGroupEnd) {
+      throw new Error('cogp metadata: level row-group boundaries must be strictly increasing');
     }
-    const finalOverview = parsed.geometry_overviews.at(-1);
-    if (finalOverview && finalOverview.level !== parsed.levels.length - 1) {
-      throw new Error('cogp metadata: final geometry overview must cover the final level');
+    previousRowGroupEnd = level.row_group_end;
+    if (!Number.isFinite(level.resolution_meters) || level.resolution_meters <= 0) {
+      throw new Error(`cogp metadata: levels[${index}].resolution_meters must be positive and finite`);
+    }
+    if (level.resolution_meters >= previousResolution) {
+      throw new Error('cogp metadata: level resolutions must be strictly decreasing');
+    }
+    previousResolution = level.resolution_meters;
+    if (typeof level.geometry_column !== 'string' || level.geometry_column.length === 0) {
+      throw new Error(`cogp metadata: levels[${index}].geometry_column must be a non-empty string`);
     }
   }
   const major = Number.parseInt(parsed.version.split('.')[0] ?? '', 10);
@@ -167,6 +139,19 @@ export function extractCogpDocument(
     throw new Error(
       'COGP primary geometry must declare exactly one Point, Line, or Polygon family',
     );
+  }
+  for (const [index, level] of cogp.levels.entries()) {
+    const geometry = geo.columns[level.geometry_column];
+    if (!geometry) {
+      throw new Error(
+        `COGP levels[${index}].geometry_column \`${level.geometry_column}\` is missing from geo.columns`,
+      );
+    }
+    if (geometry.encoding !== 'WKB') {
+      throw new Error(
+        `COGP levels[${index}].geometry_column \`${level.geometry_column}\` must use WKB encoding`,
+      );
+    }
   }
   return { cogp, geo };
 }

--- a/cogp-js/src/meta.ts
+++ b/cogp-js/src/meta.ts
@@ -6,6 +6,14 @@ export interface Level {
   gsd: number;
 }
 
+export interface GeometryOverview {
+  column: string;
+  /** Index into `CogpMeta.levels`; supplies the non-null boundary. */
+  level: number;
+  /** Maximum spatial simplification error in meters. */
+  tolerance_meters: number;
+}
+
 export interface CogpGenerator {
   name: string;
   version: string;
@@ -14,6 +22,7 @@ export interface CogpGenerator {
 export interface CogpMeta {
   version: string;
   levels: Level[];
+  geometry_overviews?: GeometryOverview[];
   generator?: CogpGenerator;
   [extra: string]: unknown;
 }
@@ -45,6 +54,20 @@ export interface GeoMeta {
   [extra: string]: unknown;
 }
 
+export type GeometryFamily = 'point' | 'line' | 'polygon';
+
+export function geometryFamily(types: readonly string[]): GeometryFamily | undefined {
+  const one = (type: string): GeometryFamily | undefined => {
+    const base = type.split(/\s+/, 1)[0];
+    if (base === 'Point' || base === 'MultiPoint') return 'point';
+    if (base === 'LineString' || base === 'MultiLineString') return 'line';
+    if (base === 'Polygon' || base === 'MultiPolygon') return 'polygon';
+    return undefined;
+  };
+  const family = types[0] ? one(types[0]) : undefined;
+  return family && types.every((type) => one(type) === family) ? family : undefined;
+}
+
 export function parseCogpMeta(json: string): CogpMeta {
   const parsed = JSON.parse(json) as CogpMeta;
   if (typeof parsed.version !== 'string') {
@@ -52,6 +75,47 @@ export function parseCogpMeta(json: string): CogpMeta {
   }
   if (!Array.isArray(parsed.levels) || parsed.levels.length === 0) {
     throw new Error('cogp metadata: `levels` must be a non-empty array');
+  }
+  if (parsed.geometry_overviews !== undefined) {
+    if (!Array.isArray(parsed.geometry_overviews)) {
+      throw new Error('cogp metadata: `geometry_overviews` must be an array');
+    }
+    let previousLevel = -1;
+    let previousTolerance = Infinity;
+    const columns = new Set<string>();
+    for (const [index, overview] of parsed.geometry_overviews.entries()) {
+      if (typeof overview.column !== 'string' || overview.column.length === 0) {
+        throw new Error(
+          `cogp metadata: geometry_overviews[${index}].column must be a non-empty string`,
+        );
+      }
+      if (columns.has(overview.column)) {
+        throw new Error(`cogp metadata: duplicate geometry overview column \`${overview.column}\``);
+      }
+      columns.add(overview.column);
+      if (!Number.isInteger(overview.level) || overview.level < 0 || overview.level >= parsed.levels.length) {
+        throw new Error(`cogp metadata: geometry_overviews[${index}].level is out of range`);
+      }
+      if (overview.level <= previousLevel) {
+        throw new Error('cogp metadata: geometry overview levels must be strictly increasing');
+      }
+      previousLevel = overview.level;
+      if (!Number.isFinite(overview.tolerance_meters) || overview.tolerance_meters <= 0) {
+        throw new Error(
+          `cogp metadata: geometry_overviews[${index}].tolerance_meters must be positive and finite`,
+        );
+      }
+      if (overview.tolerance_meters >= previousTolerance) {
+        throw new Error(
+          'cogp metadata: geometry overview tolerances must be strictly decreasing',
+        );
+      }
+      previousTolerance = overview.tolerance_meters;
+    }
+    const finalOverview = parsed.geometry_overviews.at(-1);
+    if (finalOverview && finalOverview.level !== parsed.levels.length - 1) {
+      throw new Error('cogp metadata: final geometry overview must cover the final level');
+    }
   }
   const major = Number.parseInt(parsed.version.split('.')[0] ?? '', 10);
   if (major !== 0) {
@@ -96,5 +160,13 @@ export function extractCogpDocument(
   if (!cogpJson) {
     throw new Error('not a COGP file: missing `cogp` key/value metadata');
   }
-  return { cogp: parseCogpMeta(cogpJson), geo: parseGeoMeta(geoJson) };
+  const cogp = parseCogpMeta(cogpJson);
+  const geo = parseGeoMeta(geoJson);
+  const primary = geo.columns[geo.primary_column];
+  if (!primary || !geometryFamily(primary.geometry_types)) {
+    throw new Error(
+      'COGP primary geometry must declare exactly one Point, Line, or Polygon family',
+    );
+  }
+  return { cogp, geo };
 }

--- a/cogp-js/src/range-cache.ts
+++ b/cogp-js/src/range-cache.ts
@@ -1,0 +1,101 @@
+import type { AsyncBufferLike } from './coalescing-buffer.js';
+
+export const DEFAULT_RANGE_CACHE_MAX_BYTES = 128 * 1024 * 1024;
+
+export interface RangeCacheOptions {
+  /** Maximum retained response bytes. Zero keeps only in-flight deduplication. */
+  maxBytes?: number;
+}
+
+interface CacheEntry {
+  buffer: ArrayBuffer;
+  bytes: number;
+}
+
+/**
+ * Retain exact AsyncBuffer slices in least-recently-used order.
+ *
+ * Parquet readers repeatedly request the same physical column chunks when a
+ * viewport moves slightly. Caching at this boundary makes that reuse
+ * deterministic without retaining decoded rows or depending on HTTP `206`
+ * cache behavior. The caller treats returned ArrayBuffers as immutable.
+ */
+export function lruCachingAsyncBuffer(
+  source: AsyncBufferLike,
+  options: RangeCacheOptions = {},
+): AsyncBufferLike {
+  const maxBytes = options.maxBytes ?? DEFAULT_RANGE_CACHE_MAX_BYTES;
+  if (!Number.isSafeInteger(maxBytes) || maxBytes < 0) {
+    throw new Error(`range cache maxBytes must be a non-negative safe integer, got ${maxBytes}`);
+  }
+
+  const cache = new Map<string, CacheEntry>();
+  const inFlight = new Map<string, Promise<ArrayBuffer>>();
+  let retainedBytes = 0;
+
+  const remember = (key: string, buffer: ArrayBuffer): void => {
+    const bytes = buffer.byteLength;
+    if (bytes > maxBytes) return;
+
+    const previous = cache.get(key);
+    if (previous) {
+      retainedBytes -= previous.bytes;
+      cache.delete(key);
+    }
+    while (retainedBytes + bytes > maxBytes) {
+      const oldestKey = cache.keys().next().value as string | undefined;
+      if (oldestKey === undefined) break;
+      const oldest = cache.get(oldestKey)!;
+      cache.delete(oldestKey);
+      retainedBytes -= oldest.bytes;
+    }
+    cache.set(key, { buffer, bytes });
+    retainedBytes += bytes;
+  };
+
+  return {
+    byteLength: source.byteLength,
+    slice(start: number, end = source.byteLength): Promise<ArrayBuffer> {
+      if (!Number.isSafeInteger(start) || !Number.isSafeInteger(end)) {
+        return Promise.reject(new Error(`slice bounds must be safe integers, got [${start}, ${end})`));
+      }
+      if (start < 0 || end < start || end > source.byteLength) {
+        return Promise.reject(
+          new Error(`slice [${start}, ${end}) is outside buffer length ${source.byteLength}`),
+        );
+      }
+      if (start === end) return Promise.resolve(new ArrayBuffer(0));
+
+      const key = `${start}:${end}`;
+      const hit = cache.get(key);
+      if (hit) {
+        cache.delete(key);
+        cache.set(key, hit);
+        return Promise.resolve(hit.buffer);
+      }
+
+      const pending = inFlight.get(key);
+      if (pending) return pending;
+
+      let request: Promise<ArrayBuffer>;
+      try {
+        request = Promise.resolve(source.slice(start, end));
+      } catch (error) {
+        return Promise.reject(error);
+      }
+      request = request.then(
+        (buffer) => {
+          inFlight.delete(key);
+          remember(key, buffer);
+          return buffer;
+        },
+        (error: unknown) => {
+          inFlight.delete(key);
+          throw error;
+        },
+      );
+      inFlight.set(key, request);
+      return request;
+    },
+  };
+}

--- a/cogp-js/src/reader.ts
+++ b/cogp-js/src/reader.ts
@@ -17,12 +17,11 @@ import {
   type RangeCoalescingOptions,
 } from './coalescing-buffer.js';
 import { lruCachingAsyncBuffer, type RangeCacheOptions } from './range-cache.js';
-import { selectGeometryColumnByGsd, selectLevelByGsd } from './level.js';
+import { selectLevelByResolution } from './level.js';
 import {
   type BboxCovering,
   type CogpMeta,
   extractCogpDocument,
-  geometryFamily,
   type GeoMeta,
 } from './meta.js';
 
@@ -73,8 +72,8 @@ function decodeWkb(bytes: Uint8Array): unknown {
 export interface ReadOptions {
   /** Inclusive level index; defaults to the finest level (all row groups). */
   maxLevel?: number;
-  /** Select a scale-specific geometry overview and, by default, its row prefix. */
-  targetGsd?: number;
+  /** Select the level intended for this nominal ground resolution, in meters. */
+  targetResolutionMeters?: number;
   /** Spatial filter; row groups whose covering envelope misses this bbox are skipped. */
   bbox?: BboxInput;
   /** Subset of columns to materialize. */
@@ -154,7 +153,6 @@ export class CogpReader {
   private readonly bboxColIdx: BboxColumnIndexes;
   /** Path-in-schema of the covering bbox struct, e.g. `['bbox','xmin']`. */
   private readonly bboxPaths: BboxCovering;
-  private readonly extendedGeometry: boolean;
 
   private constructor(
     private readonly file: unknown,
@@ -179,8 +177,6 @@ export class CogpReader {
     // geometry column. Surface a clear error rather than silently falling
     // back to "no spatial filter" when the file is malformed.
     const primaryCol = this.geo.columns[this.geo.primary_column];
-    const family = geometryFamily(primaryCol?.geometry_types ?? []);
-    this.extendedGeometry = family === 'line' || family === 'polygon';
     const covering = primaryCol?.covering;
     if (!covering?.bbox) {
       throw new Error(
@@ -209,32 +205,24 @@ export class CogpReader {
   }
 
   /**
-   * Select a level index per SPEC §7. Pass a target ground-sample distance in
-   * meters; the reader returns the last level whose `gsd >= targetGsd`. If
-   * `targetGsd` is omitted (or coarser than the coarsest level), the finest /
-   * coarsest level is returned respectively.
+   * Select a level index per SPEC §7. The reader returns the last level whose
+   * `resolution_meters` is at least the requested resolution. If omitted, the
+   * finest level is returned.
    */
-  selectLevel(targetGsd?: number): number {
-    if (targetGsd === undefined) return this.levels.length - 1;
-    return selectLevelByGsd(this.levels, targetGsd);
+  selectLevel(targetResolutionMeters?: number): number {
+    if (targetResolutionMeters === undefined) return this.levels.length - 1;
+    return selectLevelByResolution(this.levels, targetResolutionMeters);
   }
 
   /**
-   * Physical WKB column precise enough for the target and complete for the
-   * prefix. Extended-geometry streaming deliberately stays on the finest
-   * complete overview when one exists. Files without overviews use the
-   * lossless primary column.
+   * Physical WKB column declared by the selected level.
    */
-  selectGeometryColumn(targetGsd?: number, maxLevel?: number): string {
-    if (targetGsd === undefined) return this.primaryGeometryColumn;
-    const minimumLevel = maxLevel ?? this.selectLevel(targetGsd);
-    return selectGeometryColumnByGsd(
-      this.cogp.geometry_overviews ?? [],
-      targetGsd,
-      minimumLevel,
-      this.primaryGeometryColumn,
-      this.extendedGeometry,
-    );
+  selectGeometryColumn(targetResolutionMeters?: number, maxLevel?: number): string {
+    if (targetResolutionMeters === undefined) {
+      return this.primaryGeometryColumn;
+    }
+    const level = maxLevel ?? this.selectLevel(targetResolutionMeters);
+    return this.levels[level]?.geometry_column ?? this.primaryGeometryColumn;
   }
 
   /**
@@ -248,7 +236,7 @@ export class CogpReader {
    * row's per-feature bbox column.
    */
   async readRows(opts: ReadOptions = {}): Promise<Record<string, unknown>[]> {
-    const maxLevel = opts.maxLevel ?? this.selectLevel(opts.targetGsd);
+    const maxLevel = opts.maxLevel ?? this.selectLevel(opts.targetResolutionMeters);
     const bbox = normalizeBbox(opts.bbox);
     const rgs = this.candidateRowGroups(maxLevel, bbox);
     const maxRows = opts.maxRows;
@@ -262,9 +250,11 @@ export class CogpReader {
     // caller provided a custom column selection that excludes it, splice the
     // struct's top-level name in transparently — hyparquet reads the whole
     // struct when you name its root.
-    const selectedGeometry = this.selectGeometryColumn(opts.targetGsd, maxLevel);
+    const selectedGeometry = this.selectGeometryColumn(opts.targetResolutionMeters, maxLevel);
     const overviewNames = new Set(
-      (this.cogp.geometry_overviews ?? []).map((overview) => overview.column),
+      this.levels
+        .map((level) => level.geometry_column)
+        .filter((column) => column !== this.primaryGeometryColumn),
     );
     const primaryRequested = !opts.columns || opts.columns.includes(this.primaryGeometryColumn);
     let columns = opts.columns;

--- a/cogp-js/src/reader.ts
+++ b/cogp-js/src/reader.ts
@@ -16,13 +16,21 @@ import {
   coalescingAsyncBuffer,
   type RangeCoalescingOptions,
 } from './coalescing-buffer.js';
-import { selectLevelByGsd } from './level.js';
-import { type BboxCovering, type CogpMeta, extractCogpDocument, type GeoMeta } from './meta.js';
+import { lruCachingAsyncBuffer, type RangeCacheOptions } from './range-cache.js';
+import { selectGeometryColumnByGsd, selectLevelByGsd } from './level.js';
+import {
+  type BboxCovering,
+  type CogpMeta,
+  extractCogpDocument,
+  geometryFamily,
+  type GeoMeta,
+} from './meta.js';
 
 // Minimal structural view of the metadata object we need; this avoids tight
 // coupling to a specific hyparquet major version's exported types.
 interface FullFileMetadata extends FileMetadataLike {
   key_value_metadata?: ReadonlyArray<{ key: string; value?: string | null }> | null;
+  schema: ReadonlyArray<{ name: string; num_children?: number }>;
 }
 
 export type BboxInput = Bbox | readonly [number, number, number, number];
@@ -32,6 +40,8 @@ export interface OpenOptions {
   byteLength?: number;
   /** Coalesce nearby concurrent HTTP ranges; enabled by default. */
   rangeCoalescing?: RangeCoalescingOptions | false;
+  /** Retain exact requested ranges in a bounded LRU; defaults to 128 MiB. */
+  rangeCache?: RangeCacheOptions | false;
 }
 
 // Cap on cumulative `num_rows` packed into a single coalesced fetch. A run
@@ -63,6 +73,8 @@ function decodeWkb(bytes: Uint8Array): unknown {
 export interface ReadOptions {
   /** Inclusive level index; defaults to the finest level (all row groups). */
   maxLevel?: number;
+  /** Select a scale-specific geometry overview and, by default, its row prefix. */
+  targetGsd?: number;
   /** Spatial filter; row groups whose covering envelope misses this bbox are skipped. */
   bbox?: BboxInput;
   /** Subset of columns to materialize. */
@@ -90,6 +102,17 @@ export interface ReadOptions {
    * etc.) are not measured.
    */
   maxRowWkbBytes?: number;
+  /**
+   * Add each source row's zero-based file index under this property name.
+   * This is useful for lightweight viewport reads that fetch full attributes
+   * later with `readRow`. The name must not collide with a physical column.
+   */
+  rowIndexColumn?: string;
+}
+
+export interface ReadRowOptions {
+  /** Subset of physical columns to materialize. */
+  columns?: string[];
 }
 
 export class CogpReader {
@@ -98,9 +121,12 @@ export class CogpReader {
     if (opts.fetch) fetchOpts['fetch'] = opts.fetch;
     if (opts.byteLength !== undefined) fetchOpts['byteLength'] = opts.byteLength;
     const source = await asyncBufferFromUrl(fetchOpts as { url: string });
-    const file = opts.rangeCoalescing === false
+    const coalesced = opts.rangeCoalescing === false
       ? source
       : coalescingAsyncBuffer(source, opts.rangeCoalescing);
+    const file = opts.rangeCache === false
+      ? coalesced
+      : lruCachingAsyncBuffer(coalesced, opts.rangeCache);
     return CogpReader.fromAsyncBuffer(file, url);
   }
 
@@ -120,14 +146,15 @@ export class CogpReader {
 
   readonly cogp: CogpMeta;
   readonly geo: GeoMeta;
+  readonly columnNames: readonly string[];
+  readonly numRows: number;
   /** Row group → flat row index of its first row. */
   private readonly rowOffsets: number[];
   /** Column indexes (within a row group's columns list) of covering bbox sub-columns. */
   private readonly bboxColIdx: BboxColumnIndexes;
   /** Path-in-schema of the covering bbox struct, e.g. `['bbox','xmin']`. */
   private readonly bboxPaths: BboxCovering;
-  /** Names of WKB-encoded geometry columns we decode lazily after filtering. */
-  private readonly geomColumns: readonly string[];
+  private readonly extendedGeometry: boolean;
 
   private constructor(
     private readonly file: unknown,
@@ -145,11 +172,15 @@ export class CogpReader {
       acc += Number(rg.num_rows ?? 0);
     }
     this.rowOffsets = offsets;
+    this.numRows = acc;
+    this.columnNames = topLevelColumnNames(metadata.schema);
 
     // SPEC: COGP mandates a per-feature bbox covering on the primary
     // geometry column. Surface a clear error rather than silently falling
     // back to "no spatial filter" when the file is malformed.
     const primaryCol = this.geo.columns[this.geo.primary_column];
+    const family = geometryFamily(primaryCol?.geometry_types ?? []);
+    this.extendedGeometry = family === 'line' || family === 'polygon';
     const covering = primaryCol?.covering;
     if (!covering?.bbox) {
       throw new Error(
@@ -163,11 +194,6 @@ export class CogpReader {
     }
     this.bboxColIdx = findBboxColumnIndexes(firstRg, covering.bbox);
 
-    const geomCols: string[] = [];
-    for (const [name, col] of Object.entries(this.geo.columns)) {
-      if (col?.encoding === 'WKB') geomCols.push(name);
-    }
-    this.geomColumns = geomCols;
   }
 
   get levels() {
@@ -194,6 +220,24 @@ export class CogpReader {
   }
 
   /**
+   * Physical WKB column precise enough for the target and complete for the
+   * prefix. Extended-geometry streaming deliberately stays on the finest
+   * complete overview when one exists. Files without overviews use the
+   * lossless primary column.
+   */
+  selectGeometryColumn(targetGsd?: number, maxLevel?: number): string {
+    if (targetGsd === undefined) return this.primaryGeometryColumn;
+    const minimumLevel = maxLevel ?? this.selectLevel(targetGsd);
+    return selectGeometryColumnByGsd(
+      this.cogp.geometry_overviews ?? [],
+      targetGsd,
+      minimumLevel,
+      this.primaryGeometryColumn,
+      this.extendedGeometry,
+    );
+  }
+
+  /**
    * Read a contiguous level prefix, optionally bbox-pruned, as plain row
    * records. The geometry column carries a GeoJSON Geometry object decoded
    * from the on-disk WKB; decoding happens lazily after bbox filtering so
@@ -204,24 +248,42 @@ export class CogpReader {
    * row's per-feature bbox column.
    */
   async readRows(opts: ReadOptions = {}): Promise<Record<string, unknown>[]> {
-    const maxLevel = opts.maxLevel ?? this.levels.length - 1;
+    const maxLevel = opts.maxLevel ?? this.selectLevel(opts.targetGsd);
     const bbox = normalizeBbox(opts.bbox);
     const rgs = this.candidateRowGroups(maxLevel, bbox);
     const maxRows = opts.maxRows;
     const maxRowWkbBytes = opts.maxRowWkbBytes;
+    const rowIndexColumn = opts.rowIndexColumn;
+    if (rowIndexColumn && this.columnNames.includes(rowIndexColumn)) {
+      throw new Error(`rowIndexColumn \`${rowIndexColumn}\` collides with a physical column`);
+    }
     let wkbBytes = 0;
     // When filtering by bbox we need the per-row bbox struct on hand. If the
     // caller provided a custom column selection that excludes it, splice the
     // struct's top-level name in transparently — hyparquet reads the whole
     // struct when you name its root.
+    const selectedGeometry = this.selectGeometryColumn(opts.targetGsd, maxLevel);
+    const overviewNames = new Set(
+      (this.cogp.geometry_overviews ?? []).map((overview) => overview.column),
+    );
+    const primaryRequested = !opts.columns || opts.columns.includes(this.primaryGeometryColumn);
     let columns = opts.columns;
+    if (columns && primaryRequested && selectedGeometry !== this.primaryGeometryColumn) {
+      columns = columns.map((column) =>
+        column === this.primaryGeometryColumn ? selectedGeometry : column
+      );
+    } else if (!columns && overviewNames.size > 0) {
+      columns = topLevelColumnNames(this.metadata.schema).filter(
+        (column) => column !== this.primaryGeometryColumn && !overviewNames.has(column),
+      );
+      columns.push(selectedGeometry);
+    }
     if (bbox && columns) {
       const top = this.bboxPaths.xmin[0]!;
       if (!columns.includes(top)) columns = [...columns, top];
     }
     const out: Record<string, unknown>[] = [];
     const paths = bbox ? this.bboxPaths : null;
-    const geomCols = this.geomColumns;
     // Returns true once a cap has been reached, signalling callers to stop
     // iterating the current row group (and the outer stream) immediately
     // rather than draining the rest of the batch. The geometry-byte check
@@ -232,24 +294,28 @@ export class CogpReader {
     //
     const acceptRow = (row: Record<string, unknown>): boolean => {
       if (maxRowWkbBytes !== undefined) {
-        let rowWkbBytes = 0;
-        for (const col of geomCols) {
-          const v = row[col];
-          if (v instanceof Uint8Array) rowWkbBytes += v.byteLength;
-        }
+        const geometry = row[selectedGeometry];
+        const rowWkbBytes = geometry instanceof Uint8Array ? geometry.byteLength : 0;
         if (wkbBytes + rowWkbBytes > maxRowWkbBytes) return true;
         wkbBytes += rowWkbBytes;
       }
-      for (const col of geomCols) {
-        const v = row[col];
-        if (v instanceof Uint8Array) row[col] = decodeWkb(v);
+      if (primaryRequested) {
+        const geometry = row[selectedGeometry];
+        if (geometry instanceof Uint8Array) {
+          row[this.primaryGeometryColumn] = decodeWkb(geometry);
+          if (selectedGeometry !== this.primaryGeometryColumn) delete row[selectedGeometry];
+        } else if (selectedGeometry !== this.primaryGeometryColumn) {
+          throw new Error(
+            `geometry overview \`${selectedGeometry}\` is null inside its declared level boundary`,
+          );
+        }
       }
       out.push(row);
       if (maxRows !== undefined && out.length >= maxRows) return true;
       return false;
     };
     let stopped = false;
-    for await (const batch of this.streamRuns(rgs, columns)) {
+    for await (const batch of this.streamRuns(rgs, columns, rowIndexColumn)) {
       if (!paths) {
         for (const row of batch) {
           if (acceptRow(row)) {
@@ -282,6 +348,31 @@ export class CogpReader {
     return out;
   }
 
+  /**
+   * Read one source row by its stable zero-based file index. Callers can keep
+   * viewport reads narrow, then fetch expensive properties only for a feature
+   * the user actually inspects.
+   */
+  async readRow(
+    rowIndex: number,
+    opts: ReadRowOptions = {},
+  ): Promise<Record<string, unknown> | null> {
+    if (!Number.isSafeInteger(rowIndex) || rowIndex < 0 || rowIndex >= this.numRows) {
+      throw new Error(`rowIndex ${rowIndex} out of range [0, ${this.numRows})`);
+    }
+    const readArgs: Record<string, unknown> = {
+      file: this.file,
+      metadata: this.metadata,
+      rowStart: rowIndex,
+      rowEnd: rowIndex + 1,
+      compressors,
+      parsers: LAZY_GEO_PARSERS,
+    };
+    if (opts.columns) readArgs['columns'] = opts.columns;
+    const rows = (await parquetReadObjects(readArgs as never)) as Record<string, unknown>[];
+    return rows[0] ?? null;
+  }
+
   /** Bbox of a single row group as derived from covering column statistics. */
   rowGroupEnvelope(rgIndex: number): Bbox | null {
     const rg = this.metadata.row_groups[rgIndex];
@@ -306,12 +397,13 @@ export class CogpReader {
   /**
    * Materialize consecutive row-group runs in order. Each run is capped at
    * `RUN_MAX_ROWS`, bounding peak memory while allowing hyparquet to combine
-   * adjacent column-chunk reads. Byte-range reuse is delegated to the HTTP
-   * cache instead of retaining decoded row objects in the JS heap.
+   * adjacent column-chunk reads. The AsyncBuffer's bounded LRU retains exact
+   * slices across calls before this method materializes decoded rows.
    */
   private async *streamRuns(
     rgIndices: number[],
     columns: string[] | undefined,
+    rowIndexColumn: string | undefined,
   ): AsyncGenerator<Record<string, unknown>[]> {
     if (rgIndices.length === 0) return;
 
@@ -329,7 +421,13 @@ export class CogpReader {
         parsers: LAZY_GEO_PARSERS,
       };
       if (columns) readArgs['columns'] = columns;
-      yield (await parquetReadObjects(readArgs as never)) as Record<string, unknown>[];
+      const rows = (await parquetReadObjects(readArgs as never)) as Record<string, unknown>[];
+      if (rowIndexColumn) {
+        for (let index = 0; index < rows.length; index++) {
+          rows[index]![rowIndexColumn] = rowStart + index;
+        }
+      }
+      yield rows;
     }
   }
 
@@ -376,4 +474,24 @@ function readNum(row: Record<string, unknown>, path: readonly string[]): number 
   let cur: unknown = row;
   for (const p of path) cur = (cur as Record<string, unknown>)[p];
   return cur as number;
+}
+
+/** Top-level field names from Parquet's flattened depth-first schema list. */
+function topLevelColumnNames(
+  schema: ReadonlyArray<{ name: string; num_children?: number }>,
+): string[] {
+  const names: string[] = [];
+  const skipSubtree = (index: number): number => {
+    let next = index + 1;
+    const children = schema[index]?.num_children ?? 0;
+    for (let child = 0; child < children; child++) next = skipSubtree(next);
+    return next;
+  };
+  const rootChildren = schema[0]?.num_children ?? Math.max(schema.length - 1, 0);
+  let index = schema.length > 0 ? 1 : 0;
+  for (let child = 0; child < rootChildren && index < schema.length; child++) {
+    names.push(schema[index]!.name);
+    index = skipSubtree(index);
+  }
+  return names;
 }

--- a/cogp-js/test/level-overview.test.mjs
+++ b/cogp-js/test/level-overview.test.mjs
@@ -1,0 +1,88 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { selectGeometryColumnByGsd } from '../dist/level.js';
+import { geometryFamily, parseCogpMeta } from '../dist/meta.js';
+
+const levels = [
+  { row_group_end: 0, gsd: 4000 },
+  { row_group_end: 2, gsd: 2000 },
+  { row_group_end: 5, gsd: 1000 },
+  { row_group_end: 9, gsd: 500 },
+];
+const overviews = [
+  { column: 'geometry_ovr_0', level: 0, tolerance_meters: 3000 },
+  { column: 'geometry_ovr_1', level: 2, tolerance_meters: 1000 },
+  { column: 'geometry_ovr_2', level: 3, tolerance_meters: 50 },
+];
+
+test('selects one sufficiently fine column that covers the row prefix', () => {
+  assert.equal(
+    selectGeometryColumnByGsd(overviews, 5000, 0, 'geometry'),
+    'geometry_ovr_0',
+  );
+  assert.equal(
+    selectGeometryColumnByGsd(overviews, 1500, 1, 'geometry'),
+    'geometry_ovr_1',
+  );
+  assert.equal(
+    selectGeometryColumnByGsd(overviews, 750, 2, 'geometry'),
+    'geometry_ovr_2',
+  );
+  assert.equal(
+    selectGeometryColumnByGsd(overviews, 25, 3, 'geometry'),
+    'geometry',
+  );
+  assert.equal(
+    selectGeometryColumnByGsd(overviews, 25, 3, 'geometry', true),
+    'geometry_ovr_2',
+  );
+  assert.throws(
+    () => selectGeometryColumnByGsd(overviews.slice(0, 2), 25, 3, 'geometry', true),
+    /requires a geometry overview complete through level 3/,
+  );
+});
+
+test('uses raw WKB for extended geometry when no overview exists', () => {
+  assert.equal(
+    selectGeometryColumnByGsd([], 25, 3, 'geometry', true),
+    'geometry',
+  );
+});
+
+test('validates overview names and strictly increasing level links', () => {
+  const parsed = parseCogpMeta(JSON.stringify({
+    version: '0.2.0',
+    levels,
+    geometry_overviews: overviews,
+  }));
+  assert.equal(parsed.geometry_overviews.length, 3);
+
+  assert.throws(() => parseCogpMeta(JSON.stringify({
+    version: '0.2.0',
+    levels,
+    geometry_overviews: [overviews[1], overviews[0]],
+  })), /strictly increasing/);
+
+  assert.throws(() => parseCogpMeta(JSON.stringify({
+    version: '0.2.0',
+    levels,
+    geometry_overviews: [
+      overviews[0],
+      { ...overviews[1], tolerance_meters: 3000 },
+    ],
+  })), /strictly decreasing/);
+
+  assert.throws(() => parseCogpMeta(JSON.stringify({
+    version: '0.2.0',
+    levels,
+    geometry_overviews: overviews.slice(0, 2),
+  })), /must cover the final level/);
+});
+
+test('accepts singular and multi variants but rejects mixed geometry families', () => {
+  assert.equal(geometryFamily(['LineString', 'MultiLineString Z']), 'line');
+  assert.equal(geometryFamily(['Polygon', 'MultiPolygon']), 'polygon');
+  assert.equal(geometryFamily(['LineString', 'Polygon']), undefined);
+  assert.equal(geometryFamily([]), undefined);
+});

--- a/cogp-js/test/level-overview.test.mjs
+++ b/cogp-js/test/level-overview.test.mjs
@@ -1,83 +1,42 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
 
-import { selectGeometryColumnByGsd } from '../dist/level.js';
+import { selectLevelByResolution } from '../dist/level.js';
 import { geometryFamily, parseCogpMeta } from '../dist/meta.js';
 
 const levels = [
-  { row_group_end: 0, gsd: 4000 },
-  { row_group_end: 2, gsd: 2000 },
-  { row_group_end: 5, gsd: 1000 },
-  { row_group_end: 9, gsd: 500 },
-];
-const overviews = [
-  { column: 'geometry_ovr_0', level: 0, tolerance_meters: 3000 },
-  { column: 'geometry_ovr_1', level: 2, tolerance_meters: 1000 },
-  { column: 'geometry_ovr_2', level: 3, tolerance_meters: 50 },
+  { row_group_end: 0, resolution_meters: 4000, geometry_column: 'geometry_ovr_0' },
+  { row_group_end: 2, resolution_meters: 2000, geometry_column: 'geometry_ovr_1' },
+  { row_group_end: 5, resolution_meters: 1000, geometry_column: 'geometry_ovr_2' },
+  { row_group_end: 9, resolution_meters: 500, geometry_column: 'geometry_ovr_3' },
 ];
 
-test('selects one sufficiently fine column that covers the row prefix', () => {
-  assert.equal(
-    selectGeometryColumnByGsd(overviews, 5000, 0, 'geometry'),
-    'geometry_ovr_0',
-  );
-  assert.equal(
-    selectGeometryColumnByGsd(overviews, 1500, 1, 'geometry'),
-    'geometry_ovr_1',
-  );
-  assert.equal(
-    selectGeometryColumnByGsd(overviews, 750, 2, 'geometry'),
-    'geometry_ovr_2',
-  );
-  assert.equal(
-    selectGeometryColumnByGsd(overviews, 25, 3, 'geometry'),
-    'geometry',
-  );
-  assert.equal(
-    selectGeometryColumnByGsd(overviews, 25, 3, 'geometry', true),
-    'geometry_ovr_2',
-  );
-  assert.throws(
-    () => selectGeometryColumnByGsd(overviews.slice(0, 2), 25, 3, 'geometry', true),
-    /requires a geometry overview complete through level 3/,
-  );
+test('selects the finest level appropriate for the target resolution', () => {
+  assert.equal(selectLevelByResolution(levels, 5000), 0);
+  assert.equal(selectLevelByResolution(levels, 2500), 0);
+  assert.equal(selectLevelByResolution(levels, 1500), 1);
+  assert.equal(selectLevelByResolution(levels, 500), 3);
+  assert.equal(selectLevelByResolution(levels, 25), 3);
 });
 
-test('uses raw WKB for extended geometry when no overview exists', () => {
-  assert.equal(
-    selectGeometryColumnByGsd([], 25, 3, 'geometry', true),
-    'geometry',
-  );
-});
-
-test('validates overview names and strictly increasing level links', () => {
-  const parsed = parseCogpMeta(JSON.stringify({
-    version: '0.2.0',
-    levels,
-    geometry_overviews: overviews,
-  }));
-  assert.equal(parsed.geometry_overviews.length, 3);
+test('validates self-contained level entries', () => {
+  const parsed = parseCogpMeta(JSON.stringify({ version: '0.2.0', levels }));
+  assert.equal(parsed.levels[2].geometry_column, 'geometry_ovr_2');
 
   assert.throws(() => parseCogpMeta(JSON.stringify({
     version: '0.2.0',
-    levels,
-    geometry_overviews: [overviews[1], overviews[0]],
-  })), /strictly increasing/);
-
-  assert.throws(() => parseCogpMeta(JSON.stringify({
-    version: '0.2.0',
-    levels,
-    geometry_overviews: [
-      overviews[0],
-      { ...overviews[1], tolerance_meters: 3000 },
-    ],
+    levels: [levels[0], { ...levels[1], resolution_meters: 4000 }],
   })), /strictly decreasing/);
 
   assert.throws(() => parseCogpMeta(JSON.stringify({
     version: '0.2.0',
-    levels,
-    geometry_overviews: overviews.slice(0, 2),
-  })), /must cover the final level/);
+    levels: [{ ...levels[0], geometry_column: '' }],
+  })), /non-empty string/);
+
+  assert.throws(() => parseCogpMeta(JSON.stringify({
+    version: '0.2.0',
+    levels: [levels[1], levels[0]],
+  })), /strictly increasing/);
 });
 
 test('accepts singular and multi variants but rejects mixed geometry families', () => {

--- a/cogp-js/test/range-cache.test.mjs
+++ b/cogp-js/test/range-cache.test.mjs
@@ -1,0 +1,82 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { coalescingAsyncBuffer } from '../dist/coalescing-buffer.js';
+import { lruCachingAsyncBuffer } from '../dist/range-cache.js';
+
+function sourceFixture(size = 64) {
+  const bytes = Uint8Array.from({ length: size }, (_, i) => i & 0xff);
+  const calls = [];
+  return {
+    calls,
+    source: {
+      byteLength: size,
+      slice(start, end = size) {
+        calls.push([start, end]);
+        return bytes.slice(start, end).buffer;
+      },
+    },
+  };
+}
+
+test('reuses exact slices and evicts the least recently used bytes', async () => {
+  const { source, calls } = sourceFixture();
+  const file = lruCachingAsyncBuffer(source, { maxBytes: 8 });
+
+  await file.slice(0, 4);
+  await file.slice(4, 8);
+  await file.slice(0, 4); // refresh the first entry
+  await file.slice(8, 12); // evicts [4,8), not [0,4)
+  await file.slice(4, 8);
+
+  assert.deepEqual(calls, [[0, 4], [4, 8], [8, 12], [4, 8]]);
+});
+
+test('deduplicates identical in-flight slices', async () => {
+  const { source, calls } = sourceFixture();
+  const originalSlice = source.slice;
+  source.slice = async (start, end) => {
+    await Promise.resolve();
+    return originalSlice(start, end);
+  };
+  const file = lruCachingAsyncBuffer(source, { maxBytes: 8 });
+
+  const [a, b] = await Promise.all([file.slice(12, 16), file.slice(12, 16)]);
+
+  assert.deepEqual(calls, [[12, 16]]);
+  assert.strictEqual(a, b);
+});
+
+test('does not evict useful entries for a slice larger than the cache', async () => {
+  const { source, calls } = sourceFixture();
+  const file = lruCachingAsyncBuffer(source, { maxBytes: 4 });
+
+  await file.slice(0, 4);
+  await file.slice(4, 10);
+  await file.slice(0, 4);
+  await file.slice(4, 10);
+
+  assert.deepEqual(calls, [[0, 4], [4, 10], [4, 10]]);
+});
+
+test('validates the cache byte budget and slice bounds', async () => {
+  const { source } = sourceFixture();
+  assert.throws(() => lruCachingAsyncBuffer(source, { maxBytes: -1 }), /non-negative/);
+  const file = lruCachingAsyncBuffer(source);
+  await assert.rejects(file.slice(-1, 2), /outside buffer/);
+  await assert.rejects(file.slice(0, 65), /outside buffer/);
+});
+
+test('caches requested slices outside a coalesced source read', async () => {
+  const { source, calls } = sourceFixture();
+  const file = lruCachingAsyncBuffer(
+    coalescingAsyncBuffer(source, { maxGapBytes: 8 }),
+    { maxBytes: 64 },
+  );
+
+  await Promise.all([file.slice(10, 20), file.slice(25, 35)]);
+  assert.deepEqual(calls, [[10, 35]]);
+
+  await Promise.all([file.slice(10, 20), file.slice(25, 35)]);
+  assert.deepEqual(calls, [[10, 35]]);
+});

--- a/cogp-rs/Cargo.toml
+++ b/cogp-rs/Cargo.toml
@@ -22,6 +22,8 @@ arrow-buffer = "56"
 arrow-schema = "56"
 parquet = { version = "56", default-features = false, features = ["arrow", "snap", "zstd", "brotli", "lz4"] }
 byteorder = "1"
+geo = "0.33"
+i_overlay = "4.5.2"
 rayon = "1"
 
 [features]

--- a/cogp-rs/README.md
+++ b/cogp-rs/README.md
@@ -29,9 +29,9 @@ cogp validate output.cogp.parquet
 ```
 
 The output COGP file itself is projection-agnostic — it can be consumed by
-any renderer regardless of projection. The defaults simply pick GSDs tuned
+any renderer regardless of projection. The defaults simply pick resolutions tuned
 for a Web Mercator z0..=z16 tile pyramid (17 levels), since that's the most
-common viewer target. Pass `--gsd` to optimize for a different renderer.
+common viewer target. Pass `--resolution` to optimize for a different renderer.
 The input must be GeoParquet 1.x with a WKB geometry column containing one
 topological family (Point, Line, or Polygon); singular and Multi variants of
 that family may coexist.
@@ -49,50 +49,50 @@ Examples:
 cogp convert input.parquet output.cogp.parquet \
     --webmerc-minzoom 4 --webmerc-maxzoom 12 --row-group-size 20000
 
-# Optimize for a renderer other than Web Mercator: pass GSDs directly
+# Optimize for a renderer other than Web Mercator: pass resolutions directly
 # (meters, coarse to fine). The defaults still produce a valid COGP file for
-# any consumer — use this only when you want level GSDs tuned to a specific
+# any consumer — use this only when you want level resolutions tuned to a specific
 # pyramid.
 cogp convert input.parquet output.cogp.parquet \
-    --gsd 1000,500,100,50
+    --resolution 1000,500,100,50
 
 # Point dataset already in a projected CRS; thin points more aggressively.
 cogp convert points.parquet points.cogp.parquet \
     --input-units meters --point-thinning-factor 8
 ```
 
-Level selection (mutually exclusive). These only choose the per-level GSDs
+Level selection (mutually exclusive). These only choose the per-level resolutions
 used during conversion; the resulting COGP file is projection-agnostic and
 readable by any renderer regardless of which path you pick.
 
-- `--gsd 1000,500,100,50` — explicit ground sample distances in **meters**,
+- `--resolution 1000,500,100,50` — explicit nominal ground resolutions in **meters**,
   strictly decreasing. Use this to tune levels for a specific renderer (any
   projection — not just non-Web-Mercator).
 - `--webmerc-minzoom` / `--webmerc-maxzoom` (default `0` / `16`) — derive
-  GSDs from a Web Mercator tile pyramid:
-  `GSD(z) = 40_075_016 / (webmerc_resolution · 2^z)` m. This is the default
+  resolutions from a Web Mercator tile pyramid:
+  `resolution(z) = 40_075_016 / (webmerc_resolution · 2^z)` m. This is the default
   because Web Mercator is the most common viewer target, not because the
   output is restricted to it. Empty levels (no features assigned) are
   dropped automatically.
 - `--webmerc-resolution` (default `1024`) — units per tile side used in the
-  Web Mercator GSD formula above. `1024` is ~4× the typical 256-pixel tile
+  Web Mercator resolution formula above. `1024` is ~4× the typical 256-pixel tile
   resolution, so features collapsing within a few subpixels are deferred to
-  finer levels. Controls level granularity; ignored when `--gsd` is given.
+  finer levels. Controls level granularity; ignored when `--resolution` is given.
 
 Geometry overviews:
 
-- `--simplification-tolerance-factor` (default `1`) — multiplies the GSD at
-  each selected level to obtain that overview's simplification tolerance.
-- Hierarchy depth is data-derived, not configured. `convert` measures the exact
-  rendering WKB prefix at every candidate GSD—simplified WKB for Line/Polygon,
-  primary WKB for Point—makes that size curve monotonic, and retains the fewest
-  occupied candidates needed to keep adjacent payload growth near the 4× area
-  growth implied by halving linear resolution. The coarsest and finest occupied
-  candidates are always retained.
-- Line and Polygon datasets have one overview column per selected level. The
-  final overview covers the complete feature ladder, so rendering readers need
-  not project raw geometry. Point datasets have no overview columns because
-  their coordinates cannot be simplified; readers use the primary WKB.
+- `--simplification-tolerance-factor` (default `1`) — multiplies the resolution
+  at each selected level to obtain its internal simplification tolerance.
+- Every requested candidate resolution that introduces at least one feature is
+  retained. Empty candidates are omitted; no additional payload-based thinning
+  is applied.
+- Line and Polygon datasets have one simplified geometry column per selected
+  level. Point levels reference the primary WKB because their coordinates
+  cannot be simplified.
+- Retained XY vertices in each overview are snapped to the largest power-of-two
+  grid no coarser than that overview's tolerance. Coordinates remain f64 WKB,
+  but their zeroed low-order bits compress more effectively with ZSTD. Z/M
+  ordinates and every value in the primary geometry column remain unchanged.
 - Each overview is non-null through its linked level boundary and entirely
   null afterward. The primary WKB column remains lossless for every row.
 
@@ -115,8 +115,8 @@ Other options:
   rendering-grade, not geodesic.
 - `--point-thinning-factor` (default `4`) — point-like features (WKB
   `Point` / `MultiPoint`) thin on a grid this many times coarser per axis
-  than the level GSD, yielding approximately `factor²` fewer points than a
-  factor of `1`. Set to `1` for one winner per GSD-sized cell. Grid thinning
+  than the level resolution, yielding approximately `factor²` fewer points than a
+  factor of `1`. Set to `1` for one winner per resolution-sized cell. Grid thinning
   applies only to points; a bbox center cannot represent an extended
   geometry's footprint.
 - Line and Polygon levels are derived from simplification itself. A LineString
@@ -148,7 +148,8 @@ The output file:
 - writes a canonical `bbox` struct column (`xmin/ymin/xmax/ymax: f64`) and
   points GeoParquet 1.1 `covering.bbox` at it;
 - emits one or more row groups per level, written in coarse-to-fine order;
-- writes `cogp` metadata listing the `row_group_end` and `gsd` of each level.
+- writes self-contained `cogp` levels containing `row_group_end`,
+  `resolution_meters`, and `geometry_column`.
 
 ## Library use — reading COGP files
 
@@ -181,7 +182,7 @@ use geozero::ToJson;
 let reader = Reader::open("data.cogp.parquet")?;
 let primary = reader.primary_column().to_string();
 
-// Pre-filter row groups using bbox stats + a target GSD/zoom — these
+// Pre-filter row groups using bbox stats + a target resolution/zoom — these
 // only read the cached footer, no Parquet IO.
 let by_bbox = reader.row_groups_intersecting_bbox([139.0, 35.0, 140.0, 36.0]);
 let by_level = reader.row_groups_up_to_level(8);
@@ -243,11 +244,11 @@ let reader = Reader::try_new_async(&mut footer_reader).await?;
 let primary = reader.primary_column().to_string();
 
 // Per request: filter row groups (footer-only, no IO), then stream just
-// the bytes for those row groups. Both bbox and GSD/zoom are honored.
+// the bytes for those row groups. Both bbox and resolution/zoom are honored.
 let rgs: Vec<usize> = {
     let by_bbox = reader.row_groups_intersecting_bbox([139.0, 35.0, 140.0, 36.0]);
-    let by_gsd = reader.row_groups_up_to_gsd(500.0);
-    by_bbox.into_iter().filter(|i| by_gsd.contains(i)).collect()
+    let by_resolution = reader.row_groups_up_to_resolution(500.0);
+    by_bbox.into_iter().filter(|i| by_resolution.contains(i)).collect()
 };
 let per_request_reader = RangeCoalescingReader::try_new(
     ParquetObjectReader::new(store.clone(), path.clone()).with_file_size(head.size),
@@ -287,16 +288,14 @@ Remote range coalescing (`feature = "async"):
 
 Selectors (`&self`, no IO — they only consult the cached footer):
 
-- `levels()`, `geometry_overviews()`, `cogp_meta()`, `geo_meta()`, `primary_column()`,
+- `levels()`, `cogp_meta()`, `geo_meta()`, `primary_column()`,
   `num_row_groups()`, `parquet_metadata()`.
-- `geometry_column_for_gsd(gsd)` — the first overview whose boundary covers
-  the selected feature prefix and whose `tolerance_meters` is sufficiently
-  precise. Polygon-only data stays on the finest complete overview instead of
-  falling back to raw WKB when overviews exist. Line/Polygon files without any
-  overviews, and other geometry types, retain the lossless fallback.
+- `geometry_column_for_resolution(resolution)` — the geometry column declared
+  by the level selected for the target ground resolution.
 - `row_groups_in_level(i)` — one level.
 - `row_groups_up_to_level(i)` — every level up to and including `i`.
-- `row_groups_up_to_gsd(min_gsd)` — every level whose GSD is `>= min_gsd`.
+- `row_groups_up_to_resolution(target)` — every level whose
+  `resolution_meters` is `>= target`.
 - `row_groups_intersecting_bbox([xmin, ymin, xmax, ymax])` — row groups whose
   covering-bbox envelope intersects the query, via Parquet column statistics.
 
@@ -318,7 +317,9 @@ Checks SPEC §5:
 - each covering bbox column has Parquet row group min/max statistics;
 - `cogp` metadata is present with a non-empty `levels` array;
 - `row_group_end` values are strictly increasing and end at `num_row_groups - 1`;
-- `gsd` values are positive and strictly decreasing.
+- `resolution_meters` values are positive and strictly decreasing;
+- every `geometry_column` is a declared physical WKB column complete through
+  its referenced row-group prefix.
 
 Exits non-zero on failure.
 

--- a/cogp-rs/README.md
+++ b/cogp-rs/README.md
@@ -84,13 +84,15 @@ Geometry overviews:
 - `--simplification-tolerance-factor` (default `1`) — multiplies the GSD at
   each selected level to obtain that overview's simplification tolerance.
 - Hierarchy depth is data-derived, not configured. `convert` measures the exact
-  simplified WKB prefix at every candidate GSD, makes that size curve monotonic,
-  and retains the fewest occupied candidates needed to keep adjacent payload
-  growth near the 4× area growth implied by halving linear resolution. The
-  coarsest and finest occupied candidates are always retained.
-- Every selected level has exactly one overview column. The final overview
-  covers the complete feature ladder, so rendering readers need not project raw
-  geometry.
+  rendering WKB prefix at every candidate GSD—simplified WKB for Line/Polygon,
+  primary WKB for Point—makes that size curve monotonic, and retains the fewest
+  occupied candidates needed to keep adjacent payload growth near the 4× area
+  growth implied by halving linear resolution. The coarsest and finest occupied
+  candidates are always retained.
+- Line and Polygon datasets have one overview column per selected level. The
+  final overview covers the complete feature ladder, so rendering readers need
+  not project raw geometry. Point datasets have no overview columns because
+  their coordinates cannot be simplified; readers use the primary WKB.
 - Each overview is non-null through its linked level boundary and entirely
   null afterward. The primary WKB column remains lossless for every row.
 
@@ -100,10 +102,11 @@ Other options:
   Row group boundaries always align with level boundaries.
 - `--row-group-max-bytes` (default `4194304`, 4 MiB) — max cumulative WKB
   payload per row group, measured against the largest non-null geometry
-  overview for each row. The lossless primary WKB is deliberately excluded
-  because rendering readers do not project it. This must be a numeric byte
-  count without suffixes. A single indivisible geometry may exceed the target
-  and receives its own row group.
+  overview for each row. For Point data, which has no overviews, the primary
+  WKB supplies the budget. The lossless primary WKB is excluded only when
+  rendering overviews exist. This must be a numeric byte count without suffixes.
+  A single indivisible geometry may exceed the target and receives its own row
+  group.
 - `--input-units` (default `auto`) — `auto` reads the GeoParquet `crs`
   PROJJSON (`ProjectedCRS` → meters, otherwise degrees; absent / null → degrees
   per OGC:CRS84). Override with `degrees` or `meters` explicitly.

--- a/cogp-rs/README.md
+++ b/cogp-rs/README.md
@@ -3,8 +3,10 @@
 Rust reference CLI for the [Cloud Optimized GeoParquet Profile (COGP)](https://github.com/Kanahiro/cloud-optimized-geoparquet).
 
 `convert` reorders the features of a GeoParquet file across row groups using
-point-grid density thinning, extent-based line/polygon visibility, and
-Sort-Tile-Recursive (STR) bbox packing inside each level. `validate` checks the
+point-grid density thinning for points, simplification viability for lines and
+polygons, and Sort-Tile-Recursive (STR) bbox packing inside each level. It
+derives the output hierarchy from the actual simplified WKB payload and emits
+one sparse geometry overview per selected level. `validate` checks the
 structural rules in SPEC §5.
 
 ## Install
@@ -30,7 +32,9 @@ The output COGP file itself is projection-agnostic — it can be consumed by
 any renderer regardless of projection. The defaults simply pick GSDs tuned
 for a Web Mercator z0..=z16 tile pyramid (17 levels), since that's the most
 common viewer target. Pass `--gsd` to optimize for a different renderer.
-Works on any GeoParquet 1.x file with a WKB geometry column.
+The input must be GeoParquet 1.x with a WKB geometry column containing one
+topological family (Point, Line, or Polygon); singular and Multi variants of
+that family may coexist.
 
 ## convert
 
@@ -75,14 +79,31 @@ readable by any renderer regardless of which path you pick.
   resolution, so features collapsing within a few subpixels are deferred to
   finer levels. Controls level granularity; ignored when `--gsd` is given.
 
+Geometry overviews:
+
+- `--simplification-tolerance-factor` (default `1`) — multiplies the GSD at
+  each selected level to obtain that overview's simplification tolerance.
+- Hierarchy depth is data-derived, not configured. `convert` measures the exact
+  simplified WKB prefix at every candidate GSD, makes that size curve monotonic,
+  and retains the fewest occupied candidates needed to keep adjacent payload
+  growth near the 4× area growth implied by halving linear resolution. The
+  coarsest and finest occupied candidates are always retained.
+- Every selected level has exactly one overview column. The final overview
+  covers the complete feature ladder, so rendering readers need not project raw
+  geometry.
+- Each overview is non-null through its linked level boundary and entirely
+  null afterward. The primary WKB column remains lossless for every row.
+
 Other options:
 
 - `--row-group-size` (default `10000`) — max Parquet row group size in rows.
   Row group boundaries always align with level boundaries.
-- `--row-group-max-bytes` — max estimated encoded Parquet row group size in
-  bytes. This must be a numeric byte count, without suffixes. It is enforced
-  using the Parquet writer's in-progress encoded-size estimate, checked at batch
-  granularity, so an individual row group can exceed the target slightly.
+- `--row-group-max-bytes` (default `4194304`, 4 MiB) — max cumulative WKB
+  payload per row group, measured against the largest non-null geometry
+  overview for each row. The lossless primary WKB is deliberately excluded
+  because rendering readers do not project it. This must be a numeric byte
+  count without suffixes. A single indivisible geometry may exceed the target
+  and receives its own row group.
 - `--input-units` (default `auto`) — `auto` reads the GeoParquet `crs`
   PROJJSON (`ProjectedCRS` → meters, otherwise degrees; absent / null → degrees
   per OGC:CRS84). Override with `degrees` or `meters` explicitly.
@@ -93,23 +114,14 @@ Other options:
   `Point` / `MultiPoint`) thin on a grid this many times coarser per axis
   than the level GSD, yielding approximately `factor²` fewer points than a
   factor of `1`. Set to `1` for one winner per GSD-sized cell. Grid thinning
-  applies only to points: lines and
-  polygons are assigned as soon as they meet their visibility threshold,
-  because a bbox center cannot represent an extended geometry's footprint.
-- `--line-visibility-factor` (default `2`) — coarsest level at which a
-  LineString is considered independently meaningful: its bbox diagonal must
-  reach `factor · GSD` of that level. Lines are 1D so a diagonal equal to
-  one GSD is only a hairline. This is a hard cutoff: a line shorter than the
-  threshold is excluded from that level and deferred to a finer one, so a
-  coarse-zoom read never fetches sub-resolution lines. Set to `1` for the least
-  restrictive supported threshold.
-- `--polygon-visibility-factor` (default `4`) — coarsest level at which a
-  Polygon is considered independently meaningful: its bbox diagonal must
-  reach `factor · GSD` of that level. A hard cutoff, like
-  `--line-visibility-factor`: a polygon below the threshold is excluded from
-  that level and deferred to a finer one. The default keeps coarse levels from
-  being crowded by tiny polygons. Set to `1` for the least restrictive supported
-  threshold.
+  applies only to points; a bbox center cannot represent an extended
+  geometry's footprint.
+- Line and Polygon levels are derived from simplification itself. A LineString
+  is deferred while its simplified length does not exceed the level tolerance;
+  a Polygon is deferred while simplification cannot retain a valid exterior
+  ring. Extended geometries do not compete in grid cells. Collapsed polygon
+  interior rings are dropped independently; the lossless final level remains
+  the fallback for a geometry that never survives simplification.
 - `--sort-key` — attribute column that decides which feature wins when several
   points contend for the same thinning cell. When set it is the primary criterion: the
   higher-ranked feature survives to coarser levels, so the more important one is
@@ -272,8 +284,13 @@ Remote range coalescing (`feature = "async"):
 
 Selectors (`&self`, no IO — they only consult the cached footer):
 
-- `levels()`, `cogp_meta()`, `geo_meta()`, `primary_column()`,
+- `levels()`, `geometry_overviews()`, `cogp_meta()`, `geo_meta()`, `primary_column()`,
   `num_row_groups()`, `parquet_metadata()`.
+- `geometry_column_for_gsd(gsd)` — the first overview whose boundary covers
+  the selected feature prefix and whose `tolerance_meters` is sufficiently
+  precise. Polygon-only data stays on the finest complete overview instead of
+  falling back to raw WKB when overviews exist. Line/Polygon files without any
+  overviews, and other geometry types, retain the lossless fallback.
 - `row_groups_in_level(i)` — one level.
 - `row_groups_up_to_level(i)` — every level up to and including `i`.
 - `row_groups_up_to_gsd(min_gsd)` — every level whose GSD is `>= min_gsd`.

--- a/cogp-rs/src/convert.rs
+++ b/cogp-rs/src/convert.rs
@@ -1,7 +1,8 @@
 use anyhow::{anyhow, bail, Context, Result};
 use arrow::array::{
-    Array, ArrayRef, BinaryArray, Float64Array, GenericBinaryArray, LargeBinaryArray,
-    LargeStringArray, OffsetSizeTrait, RecordBatch, StringArray, StructArray,
+    new_null_array, Array, ArrayRef, BinaryArray, BinaryBuilder, Float64Array, GenericBinaryArray,
+    LargeBinaryArray, LargeBinaryBuilder, LargeStringArray, OffsetSizeTrait, RecordBatch,
+    StringArray, StructArray,
 };
 use arrow::compute::{cast, concat, interleave, rank, SortOptions};
 use arrow::datatypes::{DataType, Field, Fields, Schema};
@@ -25,10 +26,11 @@ use std::sync::Arc;
 use std::thread;
 
 use crate::meta::{
-    BboxCovering, CogpMeta, Covering, GeoColumn, GeoMeta, Level, COGP_METADATA_KEY, COGP_VERSION,
-    GEOPARQUET_VERSION, GEO_METADATA_KEY,
+    geometry_family, BboxCovering, CogpMeta, Covering, GeoColumn, GeoMeta, GeometryFamily,
+    GeometryOverview, Level, COGP_METADATA_KEY, COGP_VERSION, GEOPARQUET_VERSION, GEO_METADATA_KEY,
 };
 use crate::wkb_bbox::{bbox_from_wkb, kind_from_wkb, Bbox, GeomKind};
+use crate::wkb_simplify::{simplification_profile, simplify_wkb};
 
 #[derive(Args)]
 pub struct ConvertArgs {
@@ -56,9 +58,14 @@ pub struct ConvertArgs {
     /// Parquet row group size in rows.
     #[arg(long, default_value_t = 10000)]
     pub row_group_size: usize,
-    /// Maximum estimated encoded Parquet row group size in bytes
-    #[arg(long)]
+    /// Maximum cumulative WKB bytes in a row group's largest usable geometry
+    /// overview.
+    #[arg(long, default_value = "4194304")]
     pub row_group_max_bytes: Option<usize>,
+    /// Simplification tolerance as a multiple of each overview level's GSD.
+    /// Every geometry in one overview column uses the same spatial tolerance.
+    #[arg(long, default_value_t = 1.0)]
+    pub simplification_tolerance_factor: f64,
     /// Coordinate units in the input file. `auto` (default) inspects the GeoParquet
     /// `crs` PROJJSON: `ProjectedCRS` → meters, otherwise degrees. Override with
     /// `degrees` or `meters` if needed.
@@ -87,23 +94,6 @@ pub struct ConvertArgs {
     /// thinning grid (one winner per GSD-sized cell).
     #[arg(long, default_value_t = 4)]
     pub point_thinning_factor: u32,
-    /// Line visibility threshold multiplier applied to `prec` when deciding
-    /// the coarsest level at which a LineString first becomes independently
-    /// meaningful. A line is eligible from level `i` once its bbox diagonal
-    /// reaches `factor · prec[i]`. Lines are 1D so a diagonal equal to `prec`
-    /// is only a hairline; the default of `2` defers such short lines to a
-    /// finer level. Set to `1` for the least restrictive supported threshold.
-    #[arg(long, default_value_t = 2)]
-    pub line_visibility_factor: u32,
-    /// Polygon visibility threshold multiplier applied to `prec` when deciding
-    /// the coarsest level at which a Polygon first becomes independently
-    /// meaningful. A polygon is eligible from level `i` once its bbox diagonal
-    /// reaches `factor · prec[i]`. Default of `4` defers polygons whose
-    /// diagonal is under ~4 grid cells to a finer level, so coarse levels aren't
-    /// crowded by tiny polygons. Set to `1` for the least restrictive supported
-    /// threshold.
-    #[arg(long, default_value_t = 4)]
-    pub polygon_visibility_factor: u32,
     /// Attribute column deciding which feature wins when several contend for the
     /// same point-thinning cell. When set it is the primary criterion: the
     /// higher-ranked feature survives to coarser levels, so the more important
@@ -137,11 +127,6 @@ pub enum InputUnits {
     Meters,
 }
 
-/// Upper bound on slice size between byte-limit checks. A fixed cap alone
-/// can't enforce `max_bytes` when per-row payload is large — see the probe
-/// logic in `write_batch_with_row_group_limits`.
-const ROW_GROUP_BYTE_CHECK_MAX_ROWS: usize = 1024;
-
 fn flushed_row_group_end<W: Write + Send>(writer: &ArrowWriter<W>) -> Result<i64> {
     let count = writer.flushed_row_groups().len();
     if count == 0 {
@@ -150,47 +135,147 @@ fn flushed_row_group_end<W: Write + Send>(writer: &ArrowWriter<W>) -> Result<i64
     Ok((count as i64) - 1)
 }
 
-fn write_batch_with_row_group_limits<W: Write + Send>(
-    writer: &mut ArrowWriter<W>,
-    batch: &RecordBatch,
+/// Owns the row-group boundary policy. Parquet's writer still enforces the
+/// hard row count, while this limiter tracks the bytes that rendering readers
+/// can actually project. In particular, lossless primary WKB does not make
+/// overview-backed row groups artificially tiny.
+struct RowGroupLimiter {
     max_rows: usize,
-    max_bytes: Option<usize>,
-) -> Result<()> {
-    let Some(max_bytes) = max_bytes else {
-        writer.write(batch)?;
-        return Ok(());
-    };
+    max_wkb_bytes: Option<usize>,
+    in_progress_wkb_bytes: usize,
+}
 
-    let mut offset = 0;
-    while offset < batch.num_rows() {
-        let buffered_rows = writer.in_progress_rows();
-        let buffered_bytes = writer.in_progress_size();
-        let rows_until_row_limit = max_rows.saturating_sub(buffered_rows).max(1);
-
-        // Predict how many more rows fit in the remaining byte budget by
-        // extrapolating buffered bytes/row. Without a sample (fresh row group)
-        // probe a single row first, so a dataset where one row already exceeds
-        // `max_bytes` (e.g. dense MultiPolygons) cannot inflate the row group
-        // by ~1024× before the next size check.
-        let rows_until_byte_limit = if buffered_rows == 0 || buffered_bytes >= max_bytes {
-            1
-        } else {
-            let bytes_per_row = buffered_bytes.div_ceil(buffered_rows).max(1);
-            ((max_bytes - buffered_bytes) / bytes_per_row).max(1)
-        };
-
-        let rows = (batch.num_rows() - offset)
-            .min(rows_until_row_limit)
-            .min(rows_until_byte_limit)
-            .min(ROW_GROUP_BYTE_CHECK_MAX_ROWS);
-        writer.write(&batch.slice(offset, rows))?;
-        offset += rows;
-
-        if writer.in_progress_rows() > 0 && writer.in_progress_size() >= max_bytes {
-            writer.flush()?;
+impl RowGroupLimiter {
+    fn new(max_rows: usize, max_wkb_bytes: Option<usize>) -> Self {
+        Self {
+            max_rows,
+            max_wkb_bytes,
+            in_progress_wkb_bytes: 0,
         }
     }
-    Ok(())
+
+    fn write<W: Write + Send>(
+        &mut self,
+        writer: &mut ArrowWriter<W>,
+        batch: &RecordBatch,
+        render_geometry_columns: &[usize],
+    ) -> Result<()> {
+        let row_wkb_bytes = render_wkb_bytes_per_row(batch, render_geometry_columns)?;
+        let mut offset = 0;
+        while offset < batch.num_rows() {
+            if writer.in_progress_rows() == 0 {
+                self.in_progress_wkb_bytes = 0;
+            }
+            if writer.in_progress_rows() >= self.max_rows
+                || (writer.in_progress_rows() > 0
+                    && self
+                        .max_wkb_bytes
+                        .is_some_and(|max| self.in_progress_wkb_bytes >= max))
+            {
+                self.flush(writer)?;
+                continue;
+            }
+
+            let row_capacity = self.max_rows - writer.in_progress_rows();
+            let available = batch.num_rows() - offset;
+            let rows = match self.max_wkb_bytes {
+                None => available.min(row_capacity),
+                Some(max_bytes) => rows_within_wkb_budget(
+                    &row_wkb_bytes[offset..],
+                    available.min(row_capacity),
+                    max_bytes.saturating_sub(self.in_progress_wkb_bytes),
+                    writer.in_progress_rows() == 0,
+                ),
+            };
+            if rows == 0 {
+                self.flush(writer)?;
+                continue;
+            }
+
+            let added_wkb_bytes = row_wkb_bytes[offset..offset + rows]
+                .iter()
+                .fold(0usize, |total, bytes| total.saturating_add(*bytes));
+            writer.write(&batch.slice(offset, rows))?;
+            offset += rows;
+
+            // ArrowWriter auto-flushes on its row limit. Keep our accounting
+            // synchronized with that implicit boundary.
+            if writer.in_progress_rows() == 0 {
+                self.in_progress_wkb_bytes = 0;
+            } else {
+                self.in_progress_wkb_bytes =
+                    self.in_progress_wkb_bytes.saturating_add(added_wkb_bytes);
+                if self
+                    .max_wkb_bytes
+                    .is_some_and(|max| self.in_progress_wkb_bytes >= max)
+                {
+                    self.flush(writer)?;
+                }
+            }
+        }
+        Ok(())
+    }
+
+    fn flush<W: Write + Send>(&mut self, writer: &mut ArrowWriter<W>) -> Result<()> {
+        writer.flush()?;
+        self.in_progress_wkb_bytes = 0;
+        Ok(())
+    }
+}
+
+/// For every row, use the largest non-null overview payload. A row group may
+/// be read at several display scales, so budgeting only the coarsest overview
+/// would leave finer overview fetches unbounded.
+fn render_wkb_bytes_per_row(
+    batch: &RecordBatch,
+    render_geometry_columns: &[usize],
+) -> Result<Vec<usize>> {
+    let mut sizes = vec![0; batch.num_rows()];
+    for &column_index in render_geometry_columns {
+        let column = batch.column(column_index);
+        if let Some(values) = column.as_any().downcast_ref::<BinaryArray>() {
+            for (row, size) in sizes.iter_mut().enumerate() {
+                if !values.is_null(row) {
+                    *size = (*size).max(values.value(row).len());
+                }
+            }
+        } else if let Some(values) = column.as_any().downcast_ref::<LargeBinaryArray>() {
+            for (row, size) in sizes.iter_mut().enumerate() {
+                if !values.is_null(row) {
+                    *size = (*size).max(values.value(row).len());
+                }
+            }
+        } else {
+            bail!(
+                "render geometry column `{}` is not WKB Binary/LargeBinary",
+                batch.schema().field(column_index).name()
+            );
+        }
+    }
+    Ok(sizes)
+}
+
+fn rows_within_wkb_budget(
+    row_wkb_bytes: &[usize],
+    max_rows: usize,
+    remaining_bytes: usize,
+    empty_row_group: bool,
+) -> usize {
+    let mut rows = 0;
+    let mut bytes = 0usize;
+    for &row_bytes in row_wkb_bytes.iter().take(max_rows) {
+        if bytes.saturating_add(row_bytes) > remaining_bytes {
+            // A single geometry is indivisible. Give it a one-row group so it
+            // cannot force unrelated rows over the target as well.
+            if rows == 0 && empty_row_group {
+                return 1;
+            }
+            break;
+        }
+        bytes = bytes.saturating_add(row_bytes);
+        rows += 1;
+    }
+    rows
 }
 
 /// Inspect the GeoParquet column `crs` PROJJSON value to guess coordinate units.
@@ -300,20 +385,17 @@ pub fn run(args: ConvertArgs) -> Result<()> {
             args.point_thinning_factor
         );
     }
-    if args.line_visibility_factor == 0 {
-        bail!(
-            "--line-visibility-factor must be >= 1 (got {})",
-            args.line_visibility_factor
-        );
-    }
-    if args.polygon_visibility_factor == 0 {
-        bail!(
-            "--polygon-visibility-factor must be >= 1 (got {})",
-            args.polygon_visibility_factor
-        );
-    }
     if args.row_group_size == 0 {
         bail!("--row-group-size must be >= 1");
+    }
+    if args.row_group_max_bytes == Some(0) {
+        bail!("--row-group-max-bytes must be >= 1");
+    }
+    if args.simplification_tolerance_factor.partial_cmp(&0.0) != Some(std::cmp::Ordering::Greater) {
+        bail!(
+            "--simplification-tolerance-factor must be positive (got {})",
+            args.simplification_tolerance_factor
+        );
     }
     eprintln!("[1/4] Reading input metadata: {}", args.input.display());
     let file =
@@ -349,6 +431,15 @@ pub fn run(args: ConvertArgs) -> Result<()> {
         .index_of(&geom_col_name)
         .with_context(|| format!("geometry column `{geom_col_name}` not found"))?;
     eprintln!("      geometry column: {geom_col_name}");
+    let declared_geometry_family = input_geo
+        .as_ref()
+        .and_then(|geo| geo.columns.get(&geom_col_name))
+        .and_then(|column| geometry_family(&column.geometry_types))
+        .ok_or_else(|| {
+            anyhow!(
+                "geometry column `{geom_col_name}` must declare exactly one Point, Line, or Polygon family"
+            )
+        })?;
 
     let input_units = match args.input_units {
         InputUnits::Auto => {
@@ -365,6 +456,10 @@ pub fn run(args: ConvertArgs) -> Result<()> {
         }
         explicit => explicit,
     };
+    let simplification_tolerances: Vec<f64> = gsds
+        .iter()
+        .map(|gsd| gsd_in_input_units(*gsd * args.simplification_tolerance_factor, input_units))
+        .collect();
 
     let n_rows = arrow_meta.metadata().file_metadata().num_rows() as usize;
     if n_rows == 0 {
@@ -395,6 +490,8 @@ pub fn run(args: ConvertArgs) -> Result<()> {
     let ScanResult {
         bboxes,
         kinds,
+        minimum_viable_levels,
+        candidate_wkb_sizes,
         sort_key,
     } = scan_input(
         &args.input,
@@ -402,7 +499,20 @@ pub fn run(args: ConvertArgs) -> Result<()> {
         geom_col_idx,
         covering.as_ref(),
         sort_key_idx,
+        &simplification_tolerances,
     )?;
+    let scanned_geometry_family = match kinds[0] {
+        GeomKind::Point => GeometryFamily::Point,
+        GeomKind::Line => GeometryFamily::Line,
+        GeomKind::Polygon => GeometryFamily::Polygon,
+    };
+    if kinds.iter().any(|kind| *kind != kinds[0])
+        || scanned_geometry_family != declared_geometry_family
+    {
+        bail!(
+            "COGP requires one geometry family per file, and actual WKB must match `geometry_types`"
+        );
+    }
     let existing_bbox_col: Option<String> = covering.map(|p| p.col_name);
 
     let sort_ranks = match &sort_key {
@@ -423,40 +533,33 @@ pub fn run(args: ConvertArgs) -> Result<()> {
 
     eprintln!("[3/4] Assigning features to {} level(s)", gsds.len());
     let assignment = assign_levels(
-        &bboxes,
-        &kinds,
+        FeatureMeasures {
+            bboxes: &bboxes,
+            kinds: &kinds,
+            minimum_viable_levels: &minimum_viable_levels,
+            sort_ranks: &sort_ranks,
+        },
         &gsds,
         input_units,
         args.point_thinning_factor,
-        VisibilityFactors {
-            line: args.line_visibility_factor,
-            polygon: args.polygon_visibility_factor,
-        },
-        &sort_ranks,
     )?;
-    let mut per_level_full: Vec<Vec<u32>> = vec![Vec::new(); gsds.len()];
-    for (idx, level_i) in assignment.iter().enumerate() {
-        per_level_full[*level_i as usize].push(idx as u32);
-    }
-    // SPEC §5.3 requires each level entry to have a real row group end, so a
-    // level with zero features cannot be represented. Drop those and keep the
-    // GSDs that survive.
-    let dropped = per_level_full.iter().filter(|r| r.is_empty()).count();
-    let (mut per_level, gsds): (Vec<Vec<u32>>, Vec<f64>) = per_level_full
-        .into_iter()
-        .zip(gsds.iter().copied())
-        .filter(|(rows, _)| !rows.is_empty())
-        .unzip();
-    if per_level.is_empty() {
-        bail!("no levels received any features; check input data and GSD selection");
-    }
-    if dropped > 0 {
-        eprintln!("      note: dropped {dropped} empty level(s)");
-    }
+    let candidate_payloads = candidate_wkb_payloads(&assignment, &candidate_wkb_sizes)?;
+    let selected_candidates = select_level_hierarchy(&assignment, &candidate_payloads)?;
+    let mut per_level = remap_levels(&assignment, &selected_candidates)?;
+    let gsds: Vec<f64> = selected_candidates
+        .iter()
+        .map(|candidate| gsds[*candidate])
+        .collect();
+    eprintln!(
+        "      selected {} of {} candidate level(s) from simplified WKB growth",
+        selected_candidates.len(),
+        candidate_payloads.len()
+    );
     for (i, rows) in per_level.iter().enumerate() {
         eprintln!(
-            "      level {i} (gsd={:>10.2} m): {:>9} features",
+            "      level {i} (gsd={:>10.2} m, WKB prefix={:>9} bytes): {:>9} features",
             gsds[i],
+            candidate_payloads[selected_candidates[i]],
             rows.len()
         );
     }
@@ -464,6 +567,16 @@ pub fn run(args: ConvertArgs) -> Result<()> {
     for (level_idx, rows) in per_level.iter_mut().enumerate() {
         str_pack(rows, &bboxes, args.row_group_size, level_idx);
     }
+
+    let geometry_overviews: Vec<GeometryOverview> = selected_candidates
+        .iter()
+        .enumerate()
+        .map(|(level, _)| GeometryOverview {
+            column: overview_column_name(&geom_col_name, level),
+            level,
+            tolerance_meters: gsds[level] * args.simplification_tolerance_factor,
+        })
+        .collect();
 
     eprintln!("[4/4] Writing COGP file: {}", args.output.display());
     // Replace any pre-existing `bbox` column (and the bbox covering column we
@@ -474,7 +587,11 @@ pub fn run(args: ConvertArgs) -> Result<()> {
     let mut output_fields: Vec<Arc<Field>> = Vec::new();
     let mut keep_col_indices: Vec<usize> = Vec::new();
     for (i, f) in input_schema.fields().iter().enumerate() {
-        if drop_names.contains(&f.name().as_str()) {
+        if drop_names.contains(&f.name().as_str())
+            || geometry_overviews
+                .iter()
+                .any(|overview| overview.column == f.name().as_str())
+        {
             eprintln!(
                 "      note: dropping input column `{}` (will be overwritten)",
                 f.name()
@@ -483,6 +600,16 @@ pub fn run(args: ConvertArgs) -> Result<()> {
         }
         output_fields.push(f.clone());
         keep_col_indices.push(i);
+    }
+    let overview_type = input_schema.field(geom_col_idx).data_type().clone();
+    for overview in &geometry_overviews {
+        // An overview is NULL for features introduced after its associated
+        // level, so these physical columns must be optional.
+        output_fields.push(Arc::new(Field::new(
+            &overview.column,
+            overview_type.clone(),
+            true,
+        )));
     }
     output_fields.push(Arc::new(bbox_struct_field()));
     let output_schema = Arc::new(Schema::new(output_fields));
@@ -506,6 +633,10 @@ pub fn run(args: ConvertArgs) -> Result<()> {
         .set_statistics_enabled(EnabledStatistics::Chunk)
         .set_offset_index_disabled(true)
         .set_column_dictionary_enabled(ColumnPath::from(geom_col_name.as_str()), false);
+    for overview in &geometry_overviews {
+        props_builder = props_builder
+            .set_column_dictionary_enabled(ColumnPath::from(overview.column.as_str()), false);
+    }
     for child in ["xmin", "ymin", "xmax", "ymax"] {
         let path = ColumnPath::from(vec!["bbox".to_string(), child.to_string()]);
         props_builder = props_builder.set_column_dictionary_enabled(path, false);
@@ -528,9 +659,22 @@ pub fn run(args: ConvertArgs) -> Result<()> {
     let producer_bboxes = Arc::new(bboxes);
     let producer_meta = arrow_meta.clone();
     let producer_input = args.input.clone();
+    let producer_geom_col = keep_col_indices
+        .iter()
+        .position(|index| *index == geom_col_idx)
+        .ok_or_else(|| anyhow!("internal: primary geometry column was dropped"))?;
     let producer_keep = keep_col_indices;
     let producer_per_level = per_level;
     let producer_row_group_size = args.row_group_size;
+    let overview_plan: Vec<(usize, f64)> = geometry_overviews
+        .iter()
+        .map(|overview| {
+            (
+                overview.level,
+                gsd_in_input_units(overview.tolerance_meters, input_units),
+            )
+        })
+        .collect();
     let producer = thread::spawn(move || -> Result<()> {
         let chunks: Vec<(usize, &[u32])> = producer_per_level
             .iter()
@@ -544,13 +688,19 @@ pub fn run(args: ConvertArgs) -> Result<()> {
             let gathered = wave
                 .par_iter()
                 .map(|(level_i, chunk)| {
+                    let layout = GatherLayout {
+                        output_schema: &producer_schema,
+                        geometry_col: producer_geom_col,
+                        feature_level: *level_i,
+                        overview_plan: &overview_plan,
+                    };
                     let batches = gather_chunk(
                         &producer_input,
                         &producer_meta,
                         &producer_keep,
                         chunk,
                         &producer_bboxes,
-                        &producer_schema,
+                        &layout,
                     )?;
                     Ok((*level_i, batches))
                 })
@@ -568,27 +718,30 @@ pub fn run(args: ConvertArgs) -> Result<()> {
 
     let mut last_level: Option<usize> = None;
     let mut levels_meta: Vec<Level> = Vec::with_capacity(gsds.len());
-    let row_group_max_bytes = args.row_group_max_bytes;
+    let render_geometry_columns: Vec<usize> = if geometry_overviews.is_empty() {
+        vec![producer_geom_col]
+    } else {
+        geometry_overviews
+            .iter()
+            .map(|overview| output_schema.index_of(&overview.column))
+            .collect::<std::result::Result<_, _>>()?
+    };
+    let mut row_group_limiter = RowGroupLimiter::new(args.row_group_size, args.row_group_max_bytes);
     while let Ok((level_i, batch)) = rx.recv() {
         if let Some(prev) = last_level {
             if prev != level_i {
-                writer.flush()?;
+                row_group_limiter.flush(&mut writer)?;
                 levels_meta.push(Level {
                     row_group_end: flushed_row_group_end(&writer)?,
                     gsd: gsds[prev],
                 });
             }
         }
-        write_batch_with_row_group_limits(
-            &mut writer,
-            &batch,
-            args.row_group_size,
-            row_group_max_bytes,
-        )?;
+        row_group_limiter.write(&mut writer, &batch, &render_geometry_columns)?;
         last_level = Some(level_i);
     }
     if let Some(prev) = last_level {
-        writer.flush()?;
+        row_group_limiter.flush(&mut writer)?;
         levels_meta.push(Level {
             row_group_end: flushed_row_group_end(&writer)?,
             gsd: gsds[prev],
@@ -626,6 +779,17 @@ pub fn run(args: ConvertArgs) -> Result<()> {
             ]),
             crs: None,
         });
+    let primary_geo = columns
+        .get(&geom_col_name)
+        .expect("primary geometry metadata was inserted")
+        .clone();
+    for overview in &geometry_overviews {
+        let mut column_meta = primary_geo.clone();
+        // Spatial pruning remains based on the lossless primary geometry.
+        // Simplification can contract an overview's bbox.
+        column_meta.covering = None;
+        columns.insert(overview.column.clone(), column_meta);
+    }
     let geo_meta = GeoMeta {
         version: GEOPARQUET_VERSION.to_string(),
         primary_column: geom_col_name.clone(),
@@ -634,6 +798,7 @@ pub fn run(args: ConvertArgs) -> Result<()> {
     let cogp_meta = CogpMeta {
         version: COGP_VERSION.to_string(),
         levels: levels_meta,
+        geometry_overviews,
     };
 
     writer.append_key_value_metadata(KeyValue {
@@ -805,21 +970,37 @@ impl<'a> CoverCols<'a> {
 struct ScanResult {
     bboxes: Vec<Bbox>,
     kinds: Vec<GeomKind>,
+    /// First level whose simplification result remains independently
+    /// renderable. Points are viable throughout the ladder.
+    minimum_viable_levels: Vec<u16>,
+    /// Exact simplified WKB length for every row at every candidate level,
+    /// stored level-major. This is the input to deterministic hierarchy
+    /// selection after feature assignment is known.
+    candidate_wkb_sizes: Vec<Vec<u64>>,
     /// The fully materialized `--sort-key` column, when one was requested —
     /// the only column the convert still holds in memory in its entirety.
     sort_key: Option<ArrayRef>,
 }
 
+struct ScannedGeometry {
+    bbox: Bbox,
+    kind: GeomKind,
+    minimum_viable_level: u16,
+    wkb_sizes: Vec<u64>,
+}
+
 /// Pass 1: stream the file reading only the geometry column (plus, when
 /// present, the covering bbox column and the `--sort-key` column) and reduce
-/// each row to its bbox + geometry kind. Batches are dropped as soon as they
-/// are consumed, so peak memory is one batch plus the per-row outputs.
+/// each row to its bbox, geometry kind, and candidate simplification profile.
+/// Batches are dropped as soon as they are consumed, so geometry memory is one
+/// batch plus fixed-width per-row outputs.
 fn scan_input(
     input: &Path,
     meta: &ArrowReaderMetadata,
     geom_col_idx: usize,
     covering: Option<&CoveringPlan>,
     sort_key_idx: Option<usize>,
+    simplification_tolerances: &[f64],
 ) -> Result<ScanResult> {
     let mut roots: Vec<usize> = vec![geom_col_idx];
     if let Some(p) = covering {
@@ -851,6 +1032,11 @@ fn scan_input(
     let n_rows = meta.metadata().file_metadata().num_rows() as usize;
     let mut bboxes: Vec<Bbox> = Vec::with_capacity(n_rows);
     let mut kinds: Vec<GeomKind> = Vec::with_capacity(n_rows);
+    let mut minimum_viable_levels: Vec<u16> = Vec::with_capacity(n_rows);
+    let mut candidate_wkb_sizes: Vec<Vec<u64>> = simplification_tolerances
+        .iter()
+        .map(|_| Vec::with_capacity(n_rows))
+        .collect();
     let mut sort_key_parts: Vec<ArrayRef> = Vec::new();
     let mut row_base = 0usize;
     for batch in reader {
@@ -863,10 +1049,15 @@ fn scan_input(
             batch.column(proj_idx(geom_col_idx)).as_ref(),
             cover.as_ref(),
             row_base,
+            simplification_tolerances,
         )?;
-        for (bb, k) in pairs {
-            bboxes.push(bb);
-            kinds.push(k);
+        for geometry in pairs {
+            bboxes.push(geometry.bbox);
+            kinds.push(geometry.kind);
+            minimum_viable_levels.push(geometry.minimum_viable_level);
+            for (level_sizes, size) in candidate_wkb_sizes.iter_mut().zip(geometry.wkb_sizes) {
+                level_sizes.push(size);
+            }
         }
         if let Some(i) = sort_key_idx {
             sort_key_parts.push(batch.column(proj_idx(i)).clone());
@@ -880,6 +1071,8 @@ fn scan_input(
     Ok(ScanResult {
         bboxes,
         kinds,
+        minimum_viable_levels,
+        candidate_wkb_sizes,
         sort_key,
     })
 }
@@ -888,11 +1081,12 @@ fn scan_geometry_batch(
     geom: &dyn Array,
     cover: Option<&CoverCols>,
     row_base: usize,
-) -> Result<Vec<(Bbox, GeomKind)>> {
+    simplification_tolerances: &[f64],
+) -> Result<Vec<ScannedGeometry>> {
     if let Some(arr) = geom.as_any().downcast_ref::<BinaryArray>() {
-        scan_wkb_rows(arr, cover, row_base)
+        scan_wkb_rows(arr, cover, row_base, simplification_tolerances)
     } else if let Some(arr) = geom.as_any().downcast_ref::<LargeBinaryArray>() {
-        scan_wkb_rows(arr, cover, row_base)
+        scan_wkb_rows(arr, cover, row_base, simplification_tolerances)
     } else {
         bail!(
             "geometry column has unsupported type `{:?}`; only WKB Binary/LargeBinary is supported",
@@ -905,7 +1099,8 @@ fn scan_wkb_rows<O: OffsetSizeTrait>(
     arr: &GenericBinaryArray<O>,
     cover: Option<&CoverCols>,
     row_base: usize,
-) -> Result<Vec<(Bbox, GeomKind)>> {
+    simplification_tolerances: &[f64],
+) -> Result<Vec<ScannedGeometry>> {
     (0..arr.len())
         .into_par_iter()
         .map(|i| {
@@ -913,12 +1108,24 @@ fn scan_wkb_rows<O: OffsetSizeTrait>(
                 bail!("null geometry at row {}", row_base + i);
             }
             let wkb = arr.value(i);
-            if let Some(c) = cover {
+            let (bbox, kind) = if let Some(c) = cover {
                 if let Some(bb) = c.value(i) {
-                    return Ok((bb, kind_from_wkb(wkb)?));
+                    (bb, kind_from_wkb(wkb)?)
+                } else {
+                    bbox_from_wkb(wkb)?
                 }
-            }
-            bbox_from_wkb(wkb)
+            } else {
+                bbox_from_wkb(wkb)?
+            };
+            let profile = simplification_profile(wkb, simplification_tolerances)?;
+            let minimum_viable_level = u16::try_from(profile.minimum_viable_level)
+                .map_err(|_| anyhow!("too many simplification levels"))?;
+            Ok(ScannedGeometry {
+                bbox,
+                kind,
+                minimum_viable_level,
+                wkb_sizes: profile.wkb_sizes,
+            })
         })
         .collect()
 }
@@ -1050,13 +1257,20 @@ fn row_selection_for(sorted: &[u32]) -> RowSelection {
 /// Returns one batch normally; the chunk is split into several whenever its
 /// variable-width payload approaches the i32 offset budget (see
 /// `SEGMENT_MAX_BYTES`), so arbitrarily fat rows cannot overflow.
+struct GatherLayout<'a> {
+    output_schema: &'a Arc<Schema>,
+    geometry_col: usize,
+    feature_level: usize,
+    overview_plan: &'a [(usize, f64)],
+}
+
 fn gather_chunk(
     input: &Path,
     meta: &ArrowReaderMetadata,
     keep_cols: &[usize],
     chunk: &[u32],
     bboxes: &[Bbox],
-    output_schema: &Arc<Schema>,
+    layout: &GatherLayout<'_>,
 ) -> Result<Vec<RecordBatch>> {
     let mut sorted = chunk.to_vec();
     sorted.sort_unstable();
@@ -1123,28 +1337,165 @@ fn gather_chunk(
             seg_bytes += weights[seg_end];
             seg_end += 1;
         }
-        let mut cols: Vec<ArrayRef> = Vec::with_capacity(n_cols + 1);
+        let mut cols: Vec<ArrayRef> = Vec::with_capacity(n_cols + layout.overview_plan.len() + 1);
         for refs in &col_refs {
             cols.push(interleave(refs, &locs[seg_start..seg_end])?);
+        }
+        let raw_geometry = cols[layout.geometry_col].clone();
+        for (overview_level, tolerance) in layout.overview_plan {
+            if layout.feature_level <= *overview_level {
+                cols.push(simplify_geometry_array(raw_geometry.as_ref(), *tolerance)?);
+            } else {
+                cols.push(new_null_array(raw_geometry.data_type(), raw_geometry.len()));
+            }
         }
         let seg_bboxes: Vec<Bbox> = chunk[seg_start..seg_end]
             .iter()
             .map(|r| bboxes[*r as usize])
             .collect();
         cols.push(Arc::new(build_bbox_struct(&seg_bboxes)?));
-        out.push(RecordBatch::try_new(output_schema.clone(), cols)?);
+        out.push(RecordBatch::try_new(layout.output_schema.clone(), cols)?);
         seg_start = seg_end;
     }
     Ok(out)
 }
 
-/// Per-kind multipliers on `prec` for the visibility (eligibility) threshold.
-/// Points are excluded — they have no extent, so they are always eligible
-/// from level 0 regardless of any factor.
-#[derive(Clone, Copy)]
-struct VisibilityFactors {
-    line: u32,
-    polygon: u32,
+const METERS_PER_DEGREE: f64 = 111_320.0;
+
+fn gsd_in_input_units(gsd: f64, units: InputUnits) -> f64 {
+    match units {
+        InputUnits::Degrees => gsd / METERS_PER_DEGREE,
+        InputUnits::Meters => gsd,
+        InputUnits::Auto => unreachable!("input units must be resolved before conversion"),
+    }
+}
+
+/// A COG overview halves linear resolution, so its sample count and expected
+/// payload grow by four. Apply that same invariant to vector WKB prefixes: the
+/// data, rather than a caller-selected column count, decides hierarchy depth.
+const WKB_LEVEL_GROWTH_FACTOR: u64 = 4;
+
+fn candidate_wkb_payloads(
+    assignment: &[u16],
+    candidate_wkb_sizes: &[Vec<u64>],
+) -> Result<Vec<u64>> {
+    if candidate_wkb_sizes.is_empty() {
+        bail!("internal: no candidate WKB sizes");
+    }
+    let mut payloads = Vec::with_capacity(candidate_wkb_sizes.len());
+    for (level, sizes) in candidate_wkb_sizes.iter().enumerate() {
+        if sizes.len() != assignment.len() {
+            bail!("internal: candidate WKB size columns have inconsistent lengths");
+        }
+        let mut payload = 0u64;
+        for (feature_level, size) in assignment.iter().zip(sizes) {
+            if *feature_level as usize <= level {
+                payload = payload
+                    .checked_add(*size)
+                    .ok_or_else(|| anyhow!("simplified WKB payload exceeds u64"))?;
+            }
+        }
+        // RDP output is not formally monotonic for every geometry. Selection
+        // uses the prefix maximum so a finer level can never appear cheaper
+        // solely because its particular simplification happened to be smaller.
+        if let Some(previous) = payloads.last() {
+            payload = payload.max(*previous);
+        }
+        payloads.push(payload);
+    }
+    Ok(payloads)
+}
+
+fn select_level_hierarchy(assignment: &[u16], payloads: &[u64]) -> Result<Vec<usize>> {
+    if assignment.is_empty() || payloads.is_empty() {
+        bail!("internal: cannot build an empty level hierarchy");
+    }
+    let mut occupied = vec![false; payloads.len()];
+    for level in assignment {
+        let level = *level as usize;
+        if level >= payloads.len() {
+            bail!("internal: feature level {level} is outside the candidate ladder");
+        }
+        occupied[level] = true;
+    }
+    let candidates: Vec<usize> = occupied
+        .iter()
+        .enumerate()
+        .filter_map(|(level, occupied)| occupied.then_some(level))
+        .collect();
+
+    let mut selected = vec![candidates[0]];
+    let mut current = 0usize;
+    while current + 1 < candidates.len() {
+        let limit = payloads[candidates[current]].saturating_mul(WKB_LEVEL_GROWTH_FACTOR);
+        let mut next = current + 1;
+        while next + 1 < candidates.len() && payloads[candidates[next + 1]] <= limit {
+            next += 1;
+        }
+        selected.push(candidates[next]);
+        current = next;
+    }
+    Ok(selected)
+}
+
+fn remap_levels(assignment: &[u16], selected_candidates: &[usize]) -> Result<Vec<Vec<u32>>> {
+    if selected_candidates.is_empty() {
+        bail!("internal: no selected levels");
+    }
+    let mut per_level = vec![Vec::new(); selected_candidates.len()];
+    for (row, source_level) in assignment.iter().enumerate() {
+        let source_level = *source_level as usize;
+        let output_level = selected_candidates.partition_point(|level| *level < source_level);
+        let rows = per_level.get_mut(output_level).ok_or_else(|| {
+            anyhow!("internal: feature level {source_level} has no selected successor")
+        })?;
+        rows.push(u32::try_from(row).map_err(|_| anyhow!("more than u32::MAX input rows"))?);
+    }
+    Ok(per_level)
+}
+
+fn overview_column_name(primary: &str, index: usize) -> String {
+    format!("{primary}_ovr_{index}")
+}
+
+fn simplify_geometry_array(array: &dyn Array, tolerance: f64) -> Result<ArrayRef> {
+    if let Some(values) = array.as_any().downcast_ref::<BinaryArray>() {
+        let simplified: Vec<Option<Vec<u8>>> = (0..values.len())
+            .into_par_iter()
+            .map(|index| {
+                (!values.is_null(index))
+                    .then(|| simplify_wkb(values.value(index), tolerance))
+                    .transpose()
+            })
+            .collect::<Result<_>>()?;
+        let mut builder = BinaryBuilder::new();
+        for value in simplified {
+            match value {
+                Some(value) => builder.append_value(value),
+                None => builder.append_null(),
+            }
+        }
+        Ok(Arc::new(builder.finish()))
+    } else if let Some(values) = array.as_any().downcast_ref::<LargeBinaryArray>() {
+        let simplified: Vec<Option<Vec<u8>>> = (0..values.len())
+            .into_par_iter()
+            .map(|index| {
+                (!values.is_null(index))
+                    .then(|| simplify_wkb(values.value(index), tolerance))
+                    .transpose()
+            })
+            .collect::<Result<_>>()?;
+        let mut builder = LargeBinaryBuilder::new();
+        for value in simplified {
+            match value {
+                Some(value) => builder.append_value(value),
+                None => builder.append_null(),
+            }
+        }
+        Ok(Arc::new(builder.finish()))
+    } else {
+        bail!("primary geometry is not a WKB Binary/LargeBinary column")
+    }
 }
 
 /// Per-row tie-break ranks derived from the `--sort-key` attribute column: a
@@ -1168,15 +1519,9 @@ fn compute_sort_ranks(col: &dyn Array, order: SortKeyOrder) -> Result<Vec<u64>> 
 /// grid cells and the highest-priority feature in each cell is assigned. Lines and
 /// polygons are spatially extended: representing either by its bbox center can hide a
 /// feature that contributes visible information across many cells. They therefore do
-/// not compete in cells and are assigned as soon as they pass the visibility gate.
-///
-/// A feature is *eligible* at a level only once its bbox diagonal reaches
-/// `vis_factor · prec` for its kind (see `min_visible`); below that it is excluded and
-/// deferred to a finer level where it becomes independently meaningful. This is a hard
-/// gate, not a tie-break, so the reader does not fetch sub-resolution extended features
-/// at a coarse zoom. It does not impose a density bound on visible lines or polygons.
-/// The trade-off is that a lone sub-threshold feature does not appear at coarser zooms.
-/// Point-kind features have no extent and are eligible from level 0.
+/// not compete in cells. Both enter at the first level where their simplified
+/// geometry remains independently renderable. Point-kind features have no extent
+/// and are eligible from level 0.
 ///
 /// Cells already occupied by a feature assigned at a coarser level are blocked: any
 /// remaining candidate whose center re-projects into such a cell at the current
@@ -1184,20 +1529,30 @@ fn compute_sort_ranks(col: &dyn Array, order: SortKeyOrder) -> Result<Vec<u64>> 
 /// this, a tight cluster would surface one feature per level in the same visual
 /// neighborhood — a coarse winner plus near-identical fine winners around it.
 /// Blocking applies only to points.
+struct FeatureMeasures<'a> {
+    bboxes: &'a [Bbox],
+    kinds: &'a [GeomKind],
+    minimum_viable_levels: &'a [u16],
+    sort_ranks: &'a [u64],
+}
+
 fn assign_levels(
-    bboxes: &[Bbox],
-    kinds: &[GeomKind],
+    features: FeatureMeasures<'_>,
     gsds: &[f64],
     units: InputUnits,
     point_thinning_factor: u32,
-    visibility: VisibilityFactors,
-    sort_ranks: &[u64],
 ) -> Result<Vec<u16>> {
     // WGS84 equatorial circumference / 360°: meters per degree of longitude at the equator.
     // Used only as a rendering-grade scale factor — see the README note on geodesy.
     const METERS_PER_DEGREE: f64 = 111_320.0;
 
-    let n = bboxes.len();
+    let n = features.bboxes.len();
+    if features.kinds.len() != n
+        || features.minimum_viable_levels.len() != n
+        || features.sort_ranks.len() != n
+    {
+        bail!("internal: per-row assignment inputs have inconsistent lengths");
+    }
     let mut assigned: Vec<i32> = vec![-1; n];
     let mut remaining: Vec<u32> = (0..n as u32).collect();
     let last_level = (gsds.len() - 1) as u16;
@@ -1212,50 +1567,22 @@ fn assign_levels(
         .collect();
 
     let point_thin_mul = point_thinning_factor as f64;
-    let line_vis_mul = visibility.line as f64;
-    let polygon_vis_mul = visibility.polygon as f64;
 
-    // Coarsest level at which each feature is independently meaningful: its bbox
-    // diagonal ≥ `vis_factor · prec` for the feature's kind. Diagonal — rather
-    // than max(w, h) — so a 45° line is rated by its actual length, not its
-    // axis-aligned shadow. Compared in squared form to avoid a per-row sqrt.
-    // Points have no extent so are eligible from level 0. Used as a hard
-    // eligibility gate in the per-cell selection below.
-    let sq_line_vis: Vec<f64> = precs
-        .iter()
-        .map(|p| (p * line_vis_mul) * (p * line_vis_mul))
-        .collect();
-    let sq_polygon_vis: Vec<f64> = precs
-        .iter()
-        .map(|p| (p * polygon_vis_mul) * (p * polygon_vis_mul))
-        .collect();
-    let min_visible: Vec<u16> = bboxes
+    // Extended geometries use the first candidate at which their actual
+    // simplification result remains renderable. Points are eligible
+    // immediately and are density-thinned below.
+    let min_visible: Vec<u16> = features
+        .kinds
         .par_iter()
-        .zip(kinds.par_iter())
-        .map(|(b, k)| {
-            if *k == GeomKind::Point {
-                return 0u16;
-            }
-            let sq_diag = b.width().powi(2) + b.height().powi(2);
-            if sq_diag <= 0.0 {
-                return 0u16;
-            }
-            let thresholds = match k {
-                GeomKind::Line => &sq_line_vis,
-                GeomKind::Polygon => &sq_polygon_vis,
-                GeomKind::Point => unreachable!(),
-            };
-            for (i, sp) in thresholds.iter().enumerate() {
-                if sq_diag >= *sp {
-                    return i as u16;
-                }
-            }
-            last_level
+        .enumerate()
+        .map(|(row, kind)| match kind {
+            GeomKind::Point => 0,
+            GeomKind::Line | GeomKind::Polygon => features.minimum_viable_levels[row],
         })
         .collect();
 
     let cell_key = |row: u32, prec: f64| -> (i64, i64) {
-        let b = bboxes[row as usize];
+        let b = features.bboxes[row as usize];
         let ep = prec * point_thin_mul;
         ((b.cx() / ep).floor() as i64, (b.cy() / ep).floor() as i64)
     };
@@ -1271,7 +1598,13 @@ fn assign_levels(
             .map(|&row| cell_key(row, *prec))
             .collect();
 
-        let prio = |row: u32| priority(&bboxes[row as usize], sort_ranks[row as usize], row);
+        let prio = |row: u32| {
+            priority(
+                &features.bboxes[row as usize],
+                features.sort_ranks[row as usize],
+                row,
+            )
+        };
 
         // Per-cell point winner map built in parallel: each thread folds into a
         // local HashMap, then reduce merges them keeping the higher-score row
@@ -1284,7 +1617,7 @@ fn assign_levels(
                 if min_visible[row as usize] as usize > level_i {
                     return local;
                 }
-                if kinds[row as usize] != GeomKind::Point {
+                if features.kinds[row as usize] != GeomKind::Point {
                     return local;
                 }
                 let key = cell_key(row, *prec);
@@ -1325,7 +1658,7 @@ fn assign_levels(
         let extended: Vec<u32> = remaining
             .par_iter()
             .filter_map(|&row| {
-                (kinds[row as usize] != GeomKind::Point
+                (features.kinds[row as usize] != GeomKind::Point
                     && min_visible[row as usize] as usize <= level_i)
                     .then_some(row)
             })
@@ -1544,6 +1877,88 @@ mod tests {
     }
 
     #[test]
+    fn wkb_growth_selects_the_minimal_level_hierarchy() {
+        let payloads = vec![
+            15, 68, 135, 210, 316, 535, 969, 1_816, 3_421, 6_343, 11_298, 19_339, 32_048, 50_860,
+            75_756, 103_681, 131_293,
+        ];
+        let assignment: Vec<u16> = (0..payloads.len() as u16).collect();
+        assert_eq!(
+            select_level_hierarchy(&assignment, &payloads).unwrap(),
+            vec![0, 1, 3, 5, 7, 9, 11, 14, 16]
+        );
+    }
+
+    #[test]
+    fn wkb_hierarchy_ignores_empty_candidates_and_remaps_forward() {
+        let assignment = vec![0, 2, 2, 4];
+        let payloads = vec![10, 10, 30, 30, 100];
+        let selected = select_level_hierarchy(&assignment, &payloads).unwrap();
+        assert_eq!(selected, vec![0, 2, 4]);
+        assert_eq!(
+            remap_levels(&assignment, &[0, 4]).unwrap(),
+            vec![vec![0], vec![1, 2, 3]]
+        );
+    }
+
+    #[test]
+    fn candidate_payloads_include_only_the_visible_prefix() {
+        let assignment = vec![0, 1, 2];
+        let sizes = vec![vec![10, 20, 30], vec![8, 18, 28], vec![6, 16, 26]];
+        assert_eq!(
+            candidate_wkb_payloads(&assignment, &sizes).unwrap(),
+            vec![10, 26, 48]
+        );
+    }
+
+    #[test]
+    fn render_wkb_budget_ignores_primary_geometry_when_overviews_exist() {
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("geometry", DataType::Binary, false),
+            Field::new("geometry_ovr_0", DataType::Binary, true),
+            Field::new("geometry_ovr_1", DataType::Binary, true),
+        ]));
+        let raw_a = vec![0u8; 10_000];
+        let raw_b = vec![0u8; 20_000];
+        let coarse_a = vec![0u8; 30];
+        let coarse_b = vec![0u8; 40];
+        let fine_a = vec![0u8; 80];
+        let fine_b = vec![0u8; 60];
+        let batch = RecordBatch::try_new(
+            schema,
+            vec![
+                Arc::new(BinaryArray::from(vec![raw_a.as_slice(), raw_b.as_slice()])),
+                Arc::new(BinaryArray::from(vec![
+                    coarse_a.as_slice(),
+                    coarse_b.as_slice(),
+                ])),
+                Arc::new(BinaryArray::from(vec![
+                    fine_a.as_slice(),
+                    fine_b.as_slice(),
+                ])),
+            ],
+        )
+        .unwrap();
+
+        assert_eq!(
+            render_wkb_bytes_per_row(&batch, &[1, 2]).unwrap(),
+            vec![80, 60]
+        );
+        assert_eq!(
+            render_wkb_bytes_per_row(&batch, &[0]).unwrap(),
+            vec![10_000, 20_000]
+        );
+    }
+
+    #[test]
+    fn wkb_budget_splits_before_overflow_and_isolates_oversized_rows() {
+        assert_eq!(rows_within_wkb_budget(&[40, 50, 20], 3, 100, true), 2);
+        assert_eq!(rows_within_wkb_budget(&[20], 1, 10, false), 0);
+        assert_eq!(rows_within_wkb_budget(&[120, 5], 2, 100, true), 1);
+        assert_eq!(rows_within_wkb_budget(&[0, 0, 0], 2, 0, true), 2);
+    }
+
+    #[test]
     fn detect_input_units_branches() {
         // No metadata at all → degrees (CRS84 fallback).
         assert!(matches!(
@@ -1647,16 +2062,15 @@ mod tests {
         let kinds = vec![GeomKind::Point, GeomKind::Point];
         let gsds = vec![100.0, 50.0];
         let out = assign_levels(
-            &bboxes,
-            &kinds,
+            FeatureMeasures {
+                bboxes: &bboxes,
+                kinds: &kinds,
+                minimum_viable_levels: &[0, 0],
+                sort_ranks: &[0, 0],
+            },
             &gsds,
             InputUnits::Meters,
             1,
-            VisibilityFactors {
-                line: 1,
-                polygon: 1,
-            },
-            &[0, 0],
         )
         .unwrap();
         assert_eq!(out, vec![0, 0]);
@@ -1671,16 +2085,15 @@ mod tests {
         let kinds = vec![GeomKind::Point, GeomKind::Point];
         let gsds = vec![100.0, 10.0];
         let out = assign_levels(
-            &bboxes,
-            &kinds,
+            FeatureMeasures {
+                bboxes: &bboxes,
+                kinds: &kinds,
+                minimum_viable_levels: &[0, 0],
+                sort_ranks: &[0, 0],
+            },
             &gsds,
             InputUnits::Meters,
             1,
-            VisibilityFactors {
-                line: 1,
-                polygon: 1,
-            },
-            &[0, 0],
         )
         .unwrap();
         let mut sorted = out.clone();
@@ -1697,16 +2110,15 @@ mod tests {
         let kinds = vec![GeomKind::Point, GeomKind::Point];
         let gsds = vec![100.0, 10.0];
         let out = assign_levels(
-            &bboxes,
-            &kinds,
+            FeatureMeasures {
+                bboxes: &bboxes,
+                kinds: &kinds,
+                minimum_viable_levels: &[0, 0],
+                sort_ranks: &[1, 5],
+            },
             &gsds,
             InputUnits::Meters,
             1,
-            VisibilityFactors {
-                line: 1,
-                polygon: 1,
-            },
-            &[1, 5],
         )
         .unwrap();
         assert_eq!(out, vec![1, 0]);
@@ -1745,53 +2157,62 @@ mod tests {
     }
 
     #[test]
-    fn assign_levels_subthreshold_feature_deferred_to_finer_level() {
-        // A lone polygon below the visibility threshold (diagonal² ≈ 2 vs the
-        // level-0 threshold² of (10·4)² = 1600) is excluded from the coarse
-        // level by the hard gate even though its cell is otherwise empty, and
-        // deferred to the finest level. This is what bounds a coarse-zoom read
-        // by screen density instead of total dataset size.
+    fn assign_levels_defers_polygon_until_simplification_survives() {
         let bboxes = vec![bb(0.0, 0.0, 1.0, 1.0)];
         let kinds = vec![GeomKind::Polygon];
         let gsds = vec![10.0, 0.5];
         let out = assign_levels(
-            &bboxes,
-            &kinds,
+            FeatureMeasures {
+                bboxes: &bboxes,
+                kinds: &kinds,
+                minimum_viable_levels: &[1],
+                sort_ranks: &[0],
+            },
             &gsds,
             InputUnits::Meters,
             1,
-            VisibilityFactors {
-                line: 2,
-                polygon: 4,
-            },
-            &[0],
         )
         .unwrap();
         assert_eq!(out, vec![1]);
     }
 
     #[test]
-    fn assign_levels_visible_feature_beats_subthreshold_in_same_cell() {
-        // Two polygons in the same level-0 cell (pitch 10): the visible one
-        // (diagonal² = 3200 ≥ 1600) takes level 0; the sub-threshold one
-        // (diagonal² = 2) is gated out of level 0 and deferred to a finer
-        // level, not dropped.
+    fn assign_levels_defers_line_until_simplification_survives() {
+        let bboxes = vec![bb(0.0, 0.0, 0.25, 0.0)];
+        let kinds = vec![GeomKind::Line];
+        let gsds = vec![1.0, 0.1];
+        let out = assign_levels(
+            FeatureMeasures {
+                bboxes: &bboxes,
+                kinds: &kinds,
+                minimum_viable_levels: &[1],
+                sort_ranks: &[0],
+            },
+            &gsds,
+            InputUnits::Meters,
+            1,
+        )
+        .unwrap();
+        assert_eq!(out, vec![1]);
+    }
+
+    #[test]
+    fn assign_levels_does_not_make_polygons_compete_in_cells() {
         let big = bb(-15.0, -15.0, 25.0, 25.0); // center (5,5)
         let small = bb(1.0, 1.0, 2.0, 2.0); // center (1.5,1.5)
         let bboxes = vec![big, small];
         let kinds = vec![GeomKind::Polygon, GeomKind::Polygon];
         let gsds = vec![10.0, 0.5];
         let out = assign_levels(
-            &bboxes,
-            &kinds,
+            FeatureMeasures {
+                bboxes: &bboxes,
+                kinds: &kinds,
+                minimum_viable_levels: &[0, 1],
+                sort_ranks: &[0, 0],
+            },
             &gsds,
             InputUnits::Meters,
             1,
-            VisibilityFactors {
-                line: 2,
-                polygon: 4,
-            },
-            &[0, 0],
         )
         .unwrap();
         assert_eq!(out, vec![0, 1]);
@@ -1817,16 +2238,15 @@ mod tests {
         ];
         let gsds = vec![10.0, 1.0];
         let out = assign_levels(
-            &bboxes,
-            &kinds,
+            FeatureMeasures {
+                bboxes: &bboxes,
+                kinds: &kinds,
+                minimum_viable_levels: &[0, 0, 0, 0],
+                sort_ranks: &[0, 0, 0, 0],
+            },
             &gsds,
             InputUnits::Meters,
             1,
-            VisibilityFactors {
-                line: 2,
-                polygon: 4,
-            },
-            &[0, 0, 0, 0],
         )
         .unwrap();
         assert_eq!(out, vec![0, 0, 0, 0]);

--- a/cogp-rs/src/convert.rs
+++ b/cogp-rs/src/convert.rs
@@ -11,8 +11,7 @@ use parquet::arrow::arrow_reader::{
     ArrowReaderMetadata, ParquetRecordBatchReaderBuilder, RowSelection, RowSelector,
 };
 use parquet::arrow::{ArrowWriter, ProjectionMask};
-use parquet::basic::Compression;
-use parquet::basic::ZstdLevel;
+use parquet::basic::{Compression, ZstdLevel};
 use parquet::file::metadata::KeyValue;
 use parquet::file::properties::{EnabledStatistics, WriterProperties};
 use parquet::schema::types::ColumnPath;
@@ -26,11 +25,11 @@ use std::sync::Arc;
 use std::thread;
 
 use crate::meta::{
-    geometry_family, BboxCovering, CogpMeta, Covering, GeoColumn, GeoMeta, GeometryFamily,
-    GeometryOverview, Level, COGP_METADATA_KEY, COGP_VERSION, GEOPARQUET_VERSION, GEO_METADATA_KEY,
+    geometry_family, BboxCovering, CogpMeta, Covering, GeoColumn, GeoMeta, GeometryFamily, Level,
+    COGP_METADATA_KEY, COGP_VERSION, GEOPARQUET_VERSION, GEO_METADATA_KEY,
 };
 use crate::wkb_bbox::{bbox_from_wkb, kind_from_wkb, Bbox, GeomKind};
-use crate::wkb_simplify::{simplification_profile, simplify_wkb};
+use crate::wkb_simplify::{first_viable_level, simplify_wkb};
 
 #[derive(Args)]
 pub struct ConvertArgs {
@@ -38,21 +37,23 @@ pub struct ConvertArgs {
     pub input: PathBuf,
     /// Output COGP file
     pub output: PathBuf,
-    /// Comma-separated GSD list, meters, coarse to fine (e.g. 1000,500,100,50).
-    /// Projection-agnostic: each value is the ground sample distance in meters
-    /// at which a level becomes meaningful. If omitted, GSDs are auto-derived
+    /// Comma-separated ground-resolution list, meters, coarse to fine
+    /// (e.g. 1000,500,100,50). Each value is the nominal ground resolution at
+    /// which a level's feature prefix and geometry are intended for rendering.
+    /// If omitted, resolutions are auto-derived
     /// from --webmerc-minzoom..=--webmerc-maxzoom assuming a Web Mercator tile
     /// pyramid (see --webmerc-minzoom/--webmerc-maxzoom/--webmerc-resolution).
-    /// Pass --gsd directly if you target a non-Web-Mercator renderer.
+    /// Pass --resolution directly if you target a non-Web-Mercator renderer.
     #[arg(long, value_delimiter = ',', num_args = 1.., conflicts_with_all = ["webmerc_minzoom", "webmerc_maxzoom"])]
-    pub gsd: Vec<f64>,
-    /// Coarsest Web Mercator zoom level for GSD auto-derivation. Used only
-    /// when --gsd is omitted. Assumes the consumer renders on a Web Mercator
-    /// (EPSG:3857) tile pyramid; for other projections, supply --gsd.
+    pub resolution: Vec<f64>,
+    /// Coarsest Web Mercator zoom level for resolution auto-derivation. Used
+    /// only when --resolution is omitted. Assumes the consumer renders on a
+    /// Web Mercator (EPSG:3857) tile pyramid; otherwise supply --resolution.
     #[arg(long, default_value_t = 0)]
     pub webmerc_minzoom: u32,
-    /// Finest Web Mercator zoom level for GSD auto-derivation. Used only
-    /// when --gsd is omitted. Same Web Mercator assumption as --webmerc-minzoom.
+    /// Finest Web Mercator zoom level for resolution auto-derivation. Used only
+    /// when --resolution is omitted. Same Web Mercator assumption as
+    /// --webmerc-minzoom.
     #[arg(long, default_value_t = 16)]
     pub webmerc_maxzoom: u32,
     /// Parquet row group size in rows.
@@ -62,7 +63,7 @@ pub struct ConvertArgs {
     /// overview.
     #[arg(long, default_value = "4194304")]
     pub row_group_max_bytes: Option<usize>,
-    /// Simplification tolerance as a multiple of each overview level's GSD.
+    /// Simplification tolerance as a multiple of each level's resolution.
     /// Every geometry in one overview column uses the same spatial tolerance.
     #[arg(long, default_value_t = 1.0)]
     pub simplification_tolerance_factor: f64,
@@ -76,22 +77,22 @@ pub struct ConvertArgs {
     pub geometry_column: Option<String>,
     /// **Web Mercator only.** Base resolution per tile side (units) used to
     /// derive level visibility thresholds and the point-thinning grid when
-    /// auto-deriving GSDs from
-    /// --webmerc-minzoom/--webmerc-maxzoom. The level-i GSD is the ground
+    /// auto-deriving resolutions from
+    /// --webmerc-minzoom/--webmerc-maxzoom. The level-i resolution is the ground
     /// distance covered by one base unit at zoom i, computed as
     /// `40_075_016 / (base · 2^i)` meters at the equator — i.e. it bakes in
     /// the Web Mercator equatorial circumference and the standard `2^z` tile
     /// pyramid. This controls level granularity, not output coordinate
     /// precision. The default of 1024 is ~4× the typical 256-pixel tile
     /// resolution, so features collapsing within a few subpixels are deferred
-    /// to finer levels. Ignored when --gsd is given (in that case the GSDs are
-    /// taken verbatim and no projection is assumed).
+    /// to finer levels. Ignored when --resolution is given (in that case the
+    /// resolutions are taken verbatim and no projection is assumed).
     #[arg(long, default_value_t = 1024)]
     pub webmerc_resolution: u32,
     /// Point-like features (WKB Point / MultiPoint) use a thinning grid this
     /// many times coarser than `prec` per axis, yielding ~factor² fewer points
     /// per level than a factor of 1. Set to `1` for the finest supported
-    /// thinning grid (one winner per GSD-sized cell).
+    /// thinning grid (one winner per resolution-sized cell).
     #[arg(long, default_value_t = 4)]
     pub point_thinning_factor: u32,
     /// Attribute column deciding which feature wins when several contend for the
@@ -315,24 +316,24 @@ const WEB_MERCATOR_CIRCUMFERENCE_M: f64 = 40_075_016.685_578_49;
 /// Ground distance per base unit at the equator at zoom 0, for a tile sliced
 /// into `webmerc_resolution` units per side. The default of 1024 yields
 /// ~39136 m per unit at zoom 0 — the coarsest level's base visibility unit.
-fn base_unit_gsd_z0(webmerc_resolution: u32) -> f64 {
+fn base_unit_resolution_z0(webmerc_resolution: u32) -> f64 {
     WEB_MERCATOR_CIRCUMFERENCE_M / (webmerc_resolution as f64)
 }
 
-fn web_mercator_gsds(
+fn web_mercator_resolutions(
     webmerc_minzoom: u32,
     webmerc_maxzoom: u32,
     webmerc_resolution: u32,
 ) -> Vec<f64> {
-    let z0 = base_unit_gsd_z0(webmerc_resolution);
+    let z0 = base_unit_resolution_z0(webmerc_resolution);
     (webmerc_minzoom..=webmerc_maxzoom)
         .map(|z| z0 / (1u64 << z) as f64)
         .collect()
 }
 
 pub fn run(args: ConvertArgs) -> Result<()> {
-    let gsds: Vec<f64> = if !args.gsd.is_empty() {
-        args.gsd.clone()
+    let resolutions: Vec<f64> = if !args.resolution.is_empty() {
+        args.resolution.clone()
     } else {
         if args.webmerc_minzoom > args.webmerc_maxzoom {
             bail!(
@@ -353,7 +354,7 @@ pub fn run(args: ConvertArgs) -> Result<()> {
                 args.webmerc_resolution
             );
         }
-        let derived = web_mercator_gsds(
+        let derived = web_mercator_resolutions(
             args.webmerc_minzoom,
             args.webmerc_maxzoom,
             args.webmerc_resolution,
@@ -369,14 +370,17 @@ pub fn run(args: ConvertArgs) -> Result<()> {
     };
     // `partial_cmp` rather than `<=` / `<` so NaN values also fail the check
     // (NaN compares as `None`, which is not `Some(Greater)`).
-    for w in gsds.windows(2) {
+    for w in resolutions.windows(2) {
         if w[0].partial_cmp(&w[1]) != Some(std::cmp::Ordering::Greater) {
-            bail!("GSD values must be strictly decreasing, got {:?}", gsds);
+            bail!(
+                "resolution values must be strictly decreasing, got {:?}",
+                resolutions
+            );
         }
     }
-    for g in &gsds {
-        if g.partial_cmp(&0.0) != Some(std::cmp::Ordering::Greater) {
-            bail!("GSD values must be positive, got {:?}", gsds);
+    for resolution in &resolutions {
+        if resolution.partial_cmp(&0.0) != Some(std::cmp::Ordering::Greater) {
+            bail!("resolution values must be positive, got {:?}", resolutions);
         }
     }
     if args.point_thinning_factor == 0 {
@@ -456,9 +460,14 @@ pub fn run(args: ConvertArgs) -> Result<()> {
         }
         explicit => explicit,
     };
-    let simplification_tolerances: Vec<f64> = gsds
+    let simplification_tolerances: Vec<f64> = resolutions
         .iter()
-        .map(|gsd| gsd_in_input_units(*gsd * args.simplification_tolerance_factor, input_units))
+        .map(|resolution| {
+            resolution_in_input_units(
+                *resolution * args.simplification_tolerance_factor,
+                input_units,
+            )
+        })
         .collect();
 
     let n_rows = arrow_meta.metadata().file_metadata().num_rows() as usize;
@@ -491,7 +500,6 @@ pub fn run(args: ConvertArgs) -> Result<()> {
         bboxes,
         kinds,
         minimum_viable_levels,
-        candidate_wkb_sizes,
         sort_key,
     } = scan_input(
         &args.input,
@@ -531,7 +539,7 @@ pub fn run(args: ConvertArgs) -> Result<()> {
         );
     }
 
-    eprintln!("[3/4] Assigning features to {} level(s)", gsds.len());
+    eprintln!("[3/4] Assigning features to {} level(s)", resolutions.len());
     let assignment = assign_levels(
         FeatureMeasures {
             bboxes: &bboxes,
@@ -539,27 +547,25 @@ pub fn run(args: ConvertArgs) -> Result<()> {
             minimum_viable_levels: &minimum_viable_levels,
             sort_ranks: &sort_ranks,
         },
-        &gsds,
+        &resolutions,
         input_units,
         args.point_thinning_factor,
     )?;
-    let candidate_payloads = candidate_wkb_payloads(&assignment, &candidate_wkb_sizes)?;
-    let selected_candidates = select_level_hierarchy(&assignment, &candidate_payloads)?;
-    let mut per_level = remap_levels(&assignment, &selected_candidates)?;
-    let gsds: Vec<f64> = selected_candidates
+    let occupied_candidates = occupied_level_candidates(&assignment, resolutions.len())?;
+    let mut per_level = remap_levels(&assignment, &occupied_candidates)?;
+    let resolutions: Vec<f64> = occupied_candidates
         .iter()
-        .map(|candidate| gsds[*candidate])
+        .map(|candidate| resolutions[*candidate])
         .collect();
     eprintln!(
-        "      selected {} of {} candidate level(s) from rendering WKB growth",
-        selected_candidates.len(),
-        candidate_payloads.len()
+        "      retained {} of {} candidate level(s) after removing empty levels",
+        occupied_candidates.len(),
+        resolutions.len()
     );
     for (i, rows) in per_level.iter().enumerate() {
         eprintln!(
-            "      level {i} (gsd={:>10.2} m, WKB prefix={:>9} bytes): {:>9} features",
-            gsds[i],
-            candidate_payloads[selected_candidates[i]],
+            "      level {i} (resolution={:>10.2} m): {:>9} features",
+            resolutions[i],
             rows.len()
         );
     }
@@ -571,16 +577,12 @@ pub fn run(args: ConvertArgs) -> Result<()> {
     // Point coordinates cannot be simplified, so overview columns would only
     // duplicate the primary WKB. Their feature hierarchy still comes from
     // point thinning, and row-group byte budgeting falls back to primary WKB.
-    let geometry_overviews: Vec<GeometryOverview> = match scanned_geometry_family {
+    let overview_columns: Vec<String> = match scanned_geometry_family {
         GeometryFamily::Point => Vec::new(),
-        GeometryFamily::Line | GeometryFamily::Polygon => selected_candidates
+        GeometryFamily::Line | GeometryFamily::Polygon => occupied_candidates
             .iter()
             .enumerate()
-            .map(|(level, _)| GeometryOverview {
-                column: overview_column_name(&geom_col_name, level),
-                level,
-                tolerance_meters: gsds[level] * args.simplification_tolerance_factor,
-            })
+            .map(|(level, _)| overview_column_name(&geom_col_name, level))
             .collect(),
     };
 
@@ -594,9 +596,7 @@ pub fn run(args: ConvertArgs) -> Result<()> {
     let mut keep_col_indices: Vec<usize> = Vec::new();
     for (i, f) in input_schema.fields().iter().enumerate() {
         if drop_names.contains(&f.name().as_str())
-            || geometry_overviews
-                .iter()
-                .any(|overview| overview.column == f.name().as_str())
+            || overview_columns.iter().any(|column| column == f.name())
         {
             eprintln!(
                 "      note: dropping input column `{}` (will be overwritten)",
@@ -608,14 +608,10 @@ pub fn run(args: ConvertArgs) -> Result<()> {
         keep_col_indices.push(i);
     }
     let overview_type = input_schema.field(geom_col_idx).data_type().clone();
-    for overview in &geometry_overviews {
+    for column in &overview_columns {
         // An overview is NULL for features introduced after its associated
         // level, so these physical columns must be optional.
-        output_fields.push(Arc::new(Field::new(
-            &overview.column,
-            overview_type.clone(),
-            true,
-        )));
+        output_fields.push(Arc::new(Field::new(column, overview_type.clone(), true)));
     }
     output_fields.push(Arc::new(bbox_struct_field()));
     let output_schema = Arc::new(Schema::new(output_fields));
@@ -631,17 +627,25 @@ pub fn run(args: ConvertArgs) -> Result<()> {
             a
         });
 
+    // Keep compression policy internal rather than exposing another conversion
+    // parameter. Brotli 6 made the benchmark file smaller overall, but did not
+    // reduce the bytes fetched for a representative overview range and took
+    // about twice as long to decode. ZSTD 9 is the better default for COGP's
+    // latency-sensitive range-read workload.
+    let compression =
+        Compression::ZSTD(ZstdLevel::try_new(9).expect("ZSTD level 9 is supported by parquet"));
+
     // Disable dictionary encoding for the geometry column (WKB is high-cardinality, dict
     // is pure overhead) and for the bbox struct's float fields (each value is unique).
     let mut props_builder = WriterProperties::builder()
-        .set_compression(Compression::ZSTD(ZstdLevel::try_new(3)?))
+        .set_compression(compression)
         .set_max_row_group_size(args.row_group_size)
         .set_statistics_enabled(EnabledStatistics::Chunk)
         .set_offset_index_disabled(true)
         .set_column_dictionary_enabled(ColumnPath::from(geom_col_name.as_str()), false);
-    for overview in &geometry_overviews {
-        props_builder = props_builder
-            .set_column_dictionary_enabled(ColumnPath::from(overview.column.as_str()), false);
+    for column in &overview_columns {
+        props_builder =
+            props_builder.set_column_dictionary_enabled(ColumnPath::from(column.as_str()), false);
     }
     for child in ["xmin", "ymin", "xmax", "ymax"] {
         let path = ColumnPath::from(vec!["bbox".to_string(), child.to_string()]);
@@ -672,12 +676,14 @@ pub fn run(args: ConvertArgs) -> Result<()> {
     let producer_keep = keep_col_indices;
     let producer_per_level = per_level;
     let producer_row_group_size = args.row_group_size;
-    let overview_plan: Vec<(usize, f64)> = geometry_overviews
+    let overview_plan: Vec<(usize, f64)> = overview_columns
         .iter()
-        .map(|overview| {
+        .enumerate()
+        .map(|(level, _)| {
+            let tolerance_meters = resolutions[level] * args.simplification_tolerance_factor;
             (
-                overview.level,
-                gsd_in_input_units(overview.tolerance_meters, input_units),
+                level,
+                resolution_in_input_units(tolerance_meters, input_units),
             )
         })
         .collect();
@@ -723,13 +729,13 @@ pub fn run(args: ConvertArgs) -> Result<()> {
     });
 
     let mut last_level: Option<usize> = None;
-    let mut levels_meta: Vec<Level> = Vec::with_capacity(gsds.len());
-    let render_geometry_columns: Vec<usize> = if geometry_overviews.is_empty() {
+    let mut levels_meta: Vec<Level> = Vec::with_capacity(resolutions.len());
+    let render_geometry_columns: Vec<usize> = if overview_columns.is_empty() {
         vec![producer_geom_col]
     } else {
-        geometry_overviews
+        overview_columns
             .iter()
-            .map(|overview| output_schema.index_of(&overview.column))
+            .map(|column| output_schema.index_of(column))
             .collect::<std::result::Result<_, _>>()?
     };
     let mut row_group_limiter = RowGroupLimiter::new(args.row_group_size, args.row_group_max_bytes);
@@ -739,7 +745,8 @@ pub fn run(args: ConvertArgs) -> Result<()> {
                 row_group_limiter.flush(&mut writer)?;
                 levels_meta.push(Level {
                     row_group_end: flushed_row_group_end(&writer)?,
-                    gsd: gsds[prev],
+                    resolution_meters: resolutions[prev],
+                    geometry_column: overview_columns.get(prev).unwrap_or(&geom_col_name).clone(),
                 });
             }
         }
@@ -750,7 +757,8 @@ pub fn run(args: ConvertArgs) -> Result<()> {
         row_group_limiter.flush(&mut writer)?;
         levels_meta.push(Level {
             row_group_end: flushed_row_group_end(&writer)?,
-            gsd: gsds[prev],
+            resolution_meters: resolutions[prev],
+            geometry_column: overview_columns.get(prev).unwrap_or(&geom_col_name).clone(),
         });
     }
     producer
@@ -789,12 +797,12 @@ pub fn run(args: ConvertArgs) -> Result<()> {
         .get(&geom_col_name)
         .expect("primary geometry metadata was inserted")
         .clone();
-    for overview in &geometry_overviews {
+    for column in &overview_columns {
         let mut column_meta = primary_geo.clone();
         // Spatial pruning remains based on the lossless primary geometry.
         // Simplification can contract an overview's bbox.
         column_meta.covering = None;
-        columns.insert(overview.column.clone(), column_meta);
+        columns.insert(column.clone(), column_meta);
     }
     let geo_meta = GeoMeta {
         version: GEOPARQUET_VERSION.to_string(),
@@ -804,7 +812,6 @@ pub fn run(args: ConvertArgs) -> Result<()> {
     let cogp_meta = CogpMeta {
         version: COGP_VERSION.to_string(),
         levels: levels_meta,
-        geometry_overviews,
     };
 
     writer.append_key_value_metadata(KeyValue {
@@ -979,10 +986,6 @@ struct ScanResult {
     /// First level whose simplification result remains independently
     /// renderable. Points are viable throughout the ladder.
     minimum_viable_levels: Vec<u16>,
-    /// Exact simplified WKB length for every row at every candidate level,
-    /// stored level-major. This is the input to deterministic hierarchy
-    /// selection after feature assignment is known.
-    candidate_wkb_sizes: Vec<Vec<u64>>,
     /// The fully materialized `--sort-key` column, when one was requested —
     /// the only column the convert still holds in memory in its entirety.
     sort_key: Option<ArrayRef>,
@@ -992,7 +995,6 @@ struct ScannedGeometry {
     bbox: Bbox,
     kind: GeomKind,
     minimum_viable_level: u16,
-    wkb_sizes: Vec<u64>,
 }
 
 /// Pass 1: stream the file reading only the geometry column (plus, when
@@ -1039,10 +1041,6 @@ fn scan_input(
     let mut bboxes: Vec<Bbox> = Vec::with_capacity(n_rows);
     let mut kinds: Vec<GeomKind> = Vec::with_capacity(n_rows);
     let mut minimum_viable_levels: Vec<u16> = Vec::with_capacity(n_rows);
-    let mut candidate_wkb_sizes: Vec<Vec<u64>> = simplification_tolerances
-        .iter()
-        .map(|_| Vec::with_capacity(n_rows))
-        .collect();
     let mut sort_key_parts: Vec<ArrayRef> = Vec::new();
     let mut row_base = 0usize;
     for batch in reader {
@@ -1061,9 +1059,6 @@ fn scan_input(
             bboxes.push(geometry.bbox);
             kinds.push(geometry.kind);
             minimum_viable_levels.push(geometry.minimum_viable_level);
-            for (level_sizes, size) in candidate_wkb_sizes.iter_mut().zip(geometry.wkb_sizes) {
-                level_sizes.push(size);
-            }
         }
         if let Some(i) = sort_key_idx {
             sort_key_parts.push(batch.column(proj_idx(i)).clone());
@@ -1078,7 +1073,6 @@ fn scan_input(
         bboxes,
         kinds,
         minimum_viable_levels,
-        candidate_wkb_sizes,
         sort_key,
     })
 }
@@ -1123,20 +1117,17 @@ fn scan_wkb_rows<O: OffsetSizeTrait>(
             } else {
                 bbox_from_wkb(wkb)?
             };
-            let (minimum_viable_level, wkb_sizes) = match kind {
-                GeomKind::Point => (0, vec![wkb.len() as u64; simplification_tolerances.len()]),
+            let minimum_viable_level = match kind {
+                GeomKind::Point => 0,
                 GeomKind::Line | GeomKind::Polygon => {
-                    let profile = simplification_profile(wkb, simplification_tolerances)?;
-                    let minimum_viable_level = u16::try_from(profile.minimum_viable_level)
-                        .map_err(|_| anyhow!("too many simplification levels"))?;
-                    (minimum_viable_level, profile.wkb_sizes)
+                    let level = first_viable_level(wkb, simplification_tolerances)?;
+                    u16::try_from(level).map_err(|_| anyhow!("too many simplification levels"))?
                 }
             };
             Ok(ScannedGeometry {
                 bbox,
                 kind,
                 minimum_viable_level,
-                wkb_sizes,
             })
         })
         .collect()
@@ -1374,80 +1365,31 @@ fn gather_chunk(
 
 const METERS_PER_DEGREE: f64 = 111_320.0;
 
-fn gsd_in_input_units(gsd: f64, units: InputUnits) -> f64 {
+fn resolution_in_input_units(resolution: f64, units: InputUnits) -> f64 {
     match units {
-        InputUnits::Degrees => gsd / METERS_PER_DEGREE,
-        InputUnits::Meters => gsd,
+        InputUnits::Degrees => resolution / METERS_PER_DEGREE,
+        InputUnits::Meters => resolution,
         InputUnits::Auto => unreachable!("input units must be resolved before conversion"),
     }
 }
 
-/// A COG overview halves linear resolution, so its sample count and expected
-/// payload grow by four. Apply that same invariant to vector WKB prefixes: the
-/// data, rather than a caller-selected column count, decides hierarchy depth.
-const WKB_LEVEL_GROWTH_FACTOR: u64 = 4;
-
-fn candidate_wkb_payloads(
-    assignment: &[u16],
-    candidate_wkb_sizes: &[Vec<u64>],
-) -> Result<Vec<u64>> {
-    if candidate_wkb_sizes.is_empty() {
-        bail!("internal: no candidate WKB sizes");
-    }
-    let mut payloads = Vec::with_capacity(candidate_wkb_sizes.len());
-    for (level, sizes) in candidate_wkb_sizes.iter().enumerate() {
-        if sizes.len() != assignment.len() {
-            bail!("internal: candidate WKB size columns have inconsistent lengths");
-        }
-        let mut payload = 0u64;
-        for (feature_level, size) in assignment.iter().zip(sizes) {
-            if *feature_level as usize <= level {
-                payload = payload
-                    .checked_add(*size)
-                    .ok_or_else(|| anyhow!("simplified WKB payload exceeds u64"))?;
-            }
-        }
-        // RDP output is not formally monotonic for every geometry. Selection
-        // uses the prefix maximum so a finer level can never appear cheaper
-        // solely because its particular simplification happened to be smaller.
-        if let Some(previous) = payloads.last() {
-            payload = payload.max(*previous);
-        }
-        payloads.push(payload);
-    }
-    Ok(payloads)
-}
-
-fn select_level_hierarchy(assignment: &[u16], payloads: &[u64]) -> Result<Vec<usize>> {
-    if assignment.is_empty() || payloads.is_empty() {
+fn occupied_level_candidates(assignment: &[u16], candidate_count: usize) -> Result<Vec<usize>> {
+    if assignment.is_empty() || candidate_count == 0 {
         bail!("internal: cannot build an empty level hierarchy");
     }
-    let mut occupied = vec![false; payloads.len()];
+    let mut occupied = vec![false; candidate_count];
     for level in assignment {
         let level = *level as usize;
-        if level >= payloads.len() {
+        if level >= candidate_count {
             bail!("internal: feature level {level} is outside the candidate ladder");
         }
         occupied[level] = true;
     }
-    let candidates: Vec<usize> = occupied
+    Ok(occupied
         .iter()
         .enumerate()
         .filter_map(|(level, occupied)| occupied.then_some(level))
-        .collect();
-
-    let mut selected = vec![candidates[0]];
-    let mut current = 0usize;
-    while current + 1 < candidates.len() {
-        let limit = payloads[candidates[current]].saturating_mul(WKB_LEVEL_GROWTH_FACTOR);
-        let mut next = current + 1;
-        while next + 1 < candidates.len() && payloads[candidates[next + 1]] <= limit {
-            next += 1;
-        }
-        selected.push(candidates[next]);
-        current = next;
-    }
-    Ok(selected)
+        .collect())
 }
 
 fn remap_levels(assignment: &[u16], selected_candidates: &[usize]) -> Result<Vec<Vec<u32>>> {
@@ -1550,7 +1492,7 @@ struct FeatureMeasures<'a> {
 
 fn assign_levels(
     features: FeatureMeasures<'_>,
-    gsds: &[f64],
+    resolutions: &[f64],
     units: InputUnits,
     point_thinning_factor: u32,
 ) -> Result<Vec<u16>> {
@@ -1567,9 +1509,9 @@ fn assign_levels(
     }
     let mut assigned: Vec<i32> = vec![-1; n];
     let mut remaining: Vec<u32> = (0..n as u32).collect();
-    let last_level = (gsds.len() - 1) as u16;
+    let last_level = (resolutions.len() - 1) as u16;
 
-    let precs: Vec<f64> = gsds
+    let precs: Vec<f64> = resolutions
         .iter()
         .map(|g| match units {
             InputUnits::Degrees => g / METERS_PER_DEGREE,
@@ -1875,8 +1817,8 @@ mod tests {
     }
 
     #[test]
-    fn web_mercator_gsds_monotonic_and_halving() {
-        let g = web_mercator_gsds(0, 4, 1024);
+    fn web_mercator_resolutions_are_monotonic_and_halving() {
+        let g = web_mercator_resolutions(0, 4, 1024);
         assert_eq!(g.len(), 5);
         for w in g.windows(2) {
             assert!(
@@ -1889,37 +1831,15 @@ mod tests {
     }
 
     #[test]
-    fn wkb_growth_selects_the_minimal_level_hierarchy() {
-        let payloads = vec![
-            15, 68, 135, 210, 316, 535, 969, 1_816, 3_421, 6_343, 11_298, 19_339, 32_048, 50_860,
-            75_756, 103_681, 131_293,
-        ];
-        let assignment: Vec<u16> = (0..payloads.len() as u16).collect();
-        assert_eq!(
-            select_level_hierarchy(&assignment, &payloads).unwrap(),
-            vec![0, 1, 3, 5, 7, 9, 11, 14, 16]
-        );
-    }
-
-    #[test]
-    fn wkb_hierarchy_ignores_empty_candidates_and_remaps_forward() {
+    fn empty_candidates_are_removed_and_occupied_candidates_are_preserved() {
         let assignment = vec![0, 2, 2, 4];
-        let payloads = vec![10, 10, 30, 30, 100];
-        let selected = select_level_hierarchy(&assignment, &payloads).unwrap();
-        assert_eq!(selected, vec![0, 2, 4]);
+        assert_eq!(
+            occupied_level_candidates(&assignment, 5).unwrap(),
+            vec![0, 2, 4]
+        );
         assert_eq!(
             remap_levels(&assignment, &[0, 4]).unwrap(),
             vec![vec![0], vec![1, 2, 3]]
-        );
-    }
-
-    #[test]
-    fn candidate_payloads_include_only_the_visible_prefix() {
-        let assignment = vec![0, 1, 2];
-        let sizes = vec![vec![10, 20, 30], vec![8, 18, 28], vec![6, 16, 26]];
-        assert_eq!(
-            candidate_wkb_payloads(&assignment, &sizes).unwrap(),
-            vec![10, 26, 48]
         );
     }
 

--- a/cogp-rs/src/convert.rs
+++ b/cogp-rs/src/convert.rs
@@ -551,7 +551,7 @@ pub fn run(args: ConvertArgs) -> Result<()> {
         .map(|candidate| gsds[*candidate])
         .collect();
     eprintln!(
-        "      selected {} of {} candidate level(s) from simplified WKB growth",
+        "      selected {} of {} candidate level(s) from rendering WKB growth",
         selected_candidates.len(),
         candidate_payloads.len()
     );
@@ -568,15 +568,21 @@ pub fn run(args: ConvertArgs) -> Result<()> {
         str_pack(rows, &bboxes, args.row_group_size, level_idx);
     }
 
-    let geometry_overviews: Vec<GeometryOverview> = selected_candidates
-        .iter()
-        .enumerate()
-        .map(|(level, _)| GeometryOverview {
-            column: overview_column_name(&geom_col_name, level),
-            level,
-            tolerance_meters: gsds[level] * args.simplification_tolerance_factor,
-        })
-        .collect();
+    // Point coordinates cannot be simplified, so overview columns would only
+    // duplicate the primary WKB. Their feature hierarchy still comes from
+    // point thinning, and row-group byte budgeting falls back to primary WKB.
+    let geometry_overviews: Vec<GeometryOverview> = match scanned_geometry_family {
+        GeometryFamily::Point => Vec::new(),
+        GeometryFamily::Line | GeometryFamily::Polygon => selected_candidates
+            .iter()
+            .enumerate()
+            .map(|(level, _)| GeometryOverview {
+                column: overview_column_name(&geom_col_name, level),
+                level,
+                tolerance_meters: gsds[level] * args.simplification_tolerance_factor,
+            })
+            .collect(),
+    };
 
     eprintln!("[4/4] Writing COGP file: {}", args.output.display());
     // Replace any pre-existing `bbox` column (and the bbox covering column we
@@ -1117,14 +1123,20 @@ fn scan_wkb_rows<O: OffsetSizeTrait>(
             } else {
                 bbox_from_wkb(wkb)?
             };
-            let profile = simplification_profile(wkb, simplification_tolerances)?;
-            let minimum_viable_level = u16::try_from(profile.minimum_viable_level)
-                .map_err(|_| anyhow!("too many simplification levels"))?;
+            let (minimum_viable_level, wkb_sizes) = match kind {
+                GeomKind::Point => (0, vec![wkb.len() as u64; simplification_tolerances.len()]),
+                GeomKind::Line | GeomKind::Polygon => {
+                    let profile = simplification_profile(wkb, simplification_tolerances)?;
+                    let minimum_viable_level = u16::try_from(profile.minimum_viable_level)
+                        .map_err(|_| anyhow!("too many simplification levels"))?;
+                    (minimum_viable_level, profile.wkb_sizes)
+                }
+            };
             Ok(ScannedGeometry {
                 bbox,
                 kind,
                 minimum_viable_level,
-                wkb_sizes: profile.wkb_sizes,
+                wkb_sizes,
             })
         })
         .collect()

--- a/cogp-rs/src/lib.rs
+++ b/cogp-rs/src/lib.rs
@@ -5,3 +5,4 @@ mod range_coalescing;
 pub mod reader;
 pub mod validate;
 pub mod wkb_bbox;
+mod wkb_simplify;

--- a/cogp-rs/src/meta.rs
+++ b/cogp-rs/src/meta.rs
@@ -10,23 +10,13 @@ pub const GEOPARQUET_VERSION: &str = "1.1.0";
 pub struct CogpMeta {
     pub version: String,
     pub levels: Vec<Level>,
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub geometry_overviews: Vec<GeometryOverview>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Level {
     pub row_group_end: i64,
-    pub gsd: f64,
-}
-
-/// A scale-specific WKB column. `level` supplies its non-null row-group
-/// boundary; `tolerance_meters` independently describes its spatial error.
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
-pub struct GeometryOverview {
-    pub column: String,
-    pub level: usize,
-    pub tolerance_meters: f64,
+    pub resolution_meters: f64,
+    pub geometry_column: String,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -113,27 +103,23 @@ mod tests {
             levels: vec![
                 Level {
                     row_group_end: 0,
-                    gsd: 1000.0,
+                    resolution_meters: 1000.0,
+                    geometry_column: "geometry_ovr_0".into(),
                 },
                 Level {
                     row_group_end: 3,
-                    gsd: 250.0,
+                    resolution_meters: 250.0,
+                    geometry_column: "geometry_ovr_1".into(),
                 },
             ],
-            geometry_overviews: vec![GeometryOverview {
-                column: "geometry_ovr_0".into(),
-                level: 0,
-                tolerance_meters: 250.0,
-            }],
         };
         let s = serde_json::to_string(&m).unwrap();
         let parsed: CogpMeta = serde_json::from_str(&s).unwrap();
         assert_eq!(parsed.version, COGP_VERSION);
         assert_eq!(parsed.levels.len(), 2);
         assert_eq!(parsed.levels[0].row_group_end, 0);
-        assert_eq!(parsed.levels[1].gsd, 250.0);
-        assert_eq!(parsed.geometry_overviews[0].level, 0);
-        assert_eq!(parsed.geometry_overviews[0].tolerance_meters, 250.0);
+        assert_eq!(parsed.levels[1].resolution_meters, 250.0);
+        assert_eq!(parsed.levels[0].geometry_column, "geometry_ovr_0");
     }
 
     #[test]

--- a/cogp-rs/src/meta.rs
+++ b/cogp-rs/src/meta.rs
@@ -3,19 +3,30 @@ use std::collections::BTreeMap;
 
 pub const COGP_METADATA_KEY: &str = "cogp";
 pub const GEO_METADATA_KEY: &str = "geo";
-pub const COGP_VERSION: &str = "0.1.0";
+pub const COGP_VERSION: &str = "0.2.0";
 pub const GEOPARQUET_VERSION: &str = "1.1.0";
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct CogpMeta {
     pub version: String,
     pub levels: Vec<Level>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub geometry_overviews: Vec<GeometryOverview>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Level {
     pub row_group_end: i64,
     pub gsd: f64,
+}
+
+/// A scale-specific WKB column. `level` supplies its non-null row-group
+/// boundary; `tolerance_meters` independently describes its spatial error.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct GeometryOverview {
+    pub column: String,
+    pub level: usize,
+    pub tolerance_meters: f64,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -37,6 +48,33 @@ pub struct GeoColumn {
     pub crs: Option<serde_json::Value>,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum GeometryFamily {
+    Point,
+    Line,
+    Polygon,
+}
+
+/// COGP keeps one topological geometry family per file. Singular and Multi
+/// variants belong to the same family; dimensional suffixes such as `Z` and
+/// `ZM` do not change it.
+pub fn geometry_family(geometry_types: &[String]) -> Option<GeometryFamily> {
+    fn one(geometry_type: &str) -> Option<GeometryFamily> {
+        match geometry_type.split_ascii_whitespace().next()? {
+            "Point" | "MultiPoint" => Some(GeometryFamily::Point),
+            "LineString" | "MultiLineString" => Some(GeometryFamily::Line),
+            "Polygon" | "MultiPolygon" => Some(GeometryFamily::Polygon),
+            _ => None,
+        }
+    }
+
+    let family = one(geometry_types.first()?)?;
+    geometry_types
+        .iter()
+        .all(|geometry_type| one(geometry_type) == Some(family))
+        .then_some(family)
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Covering {
     pub bbox: BboxCovering,
@@ -56,13 +94,37 @@ mod tests {
     use serde_json::json;
 
     #[test]
+    fn geometry_family_accepts_singular_and_multi_but_rejects_mixed_dimensions() {
+        assert_eq!(
+            geometry_family(&["LineString".into(), "MultiLineString Z".into()]),
+            Some(GeometryFamily::Line)
+        );
+        assert_eq!(
+            geometry_family(&["LineString".into(), "Polygon".into()]),
+            None
+        );
+        assert_eq!(geometry_family(&[]), None);
+    }
+
+    #[test]
     fn cogp_meta_roundtrip() {
         let m = CogpMeta {
             version: COGP_VERSION.to_string(),
             levels: vec![
-                Level { row_group_end: 0, gsd: 1000.0 },
-                Level { row_group_end: 3, gsd: 250.0 },
+                Level {
+                    row_group_end: 0,
+                    gsd: 1000.0,
+                },
+                Level {
+                    row_group_end: 3,
+                    gsd: 250.0,
+                },
             ],
+            geometry_overviews: vec![GeometryOverview {
+                column: "geometry_ovr_0".into(),
+                level: 0,
+                tolerance_meters: 250.0,
+            }],
         };
         let s = serde_json::to_string(&m).unwrap();
         let parsed: CogpMeta = serde_json::from_str(&s).unwrap();
@@ -70,6 +132,8 @@ mod tests {
         assert_eq!(parsed.levels.len(), 2);
         assert_eq!(parsed.levels[0].row_group_end, 0);
         assert_eq!(parsed.levels[1].gsd, 250.0);
+        assert_eq!(parsed.geometry_overviews[0].level, 0);
+        assert_eq!(parsed.geometry_overviews[0].tolerance_meters, 250.0);
     }
 
     #[test]

--- a/cogp-rs/src/reader.rs
+++ b/cogp-rs/src/reader.rs
@@ -43,10 +43,7 @@ pub use parquet::arrow::async_reader::ParquetObjectReader;
 #[cfg(feature = "async")]
 pub use crate::range_coalescing::{RangeCoalescingOptions, RangeCoalescingReader};
 
-use crate::meta::{
-    geometry_family, CogpMeta, GeoMeta, GeometryFamily, GeometryOverview, Level, COGP_METADATA_KEY,
-    GEO_METADATA_KEY,
-};
+use crate::meta::{geometry_family, CogpMeta, GeoMeta, Level, COGP_METADATA_KEY, GEO_METADATA_KEY};
 
 /// Cached COGP file handle. Holds the parsed footer + COGP/GeoParquet metadata.
 /// Cheap to clone (the underlying `ArrowReaderMetadata` is `Arc`-backed) and
@@ -103,6 +100,23 @@ impl Reader {
         if geometry_family(&primary.geometry_types).is_none() {
             bail!("COGP primary geometry must declare exactly one Point, Line, or Polygon family");
         }
+        for (index, level) in cogp_meta.levels.iter().enumerate() {
+            let column = geo_meta
+                .columns
+                .get(&level.geometry_column)
+                .ok_or_else(|| {
+                    anyhow!(
+                        "COGP levels[{index}].geometry_column `{}` is missing from geo.columns",
+                        level.geometry_column
+                    )
+                })?;
+            if column.encoding != "WKB" {
+                bail!(
+                    "COGP levels[{index}].geometry_column `{}` must use WKB encoding",
+                    level.geometry_column
+                );
+            }
+        }
         Ok(Self {
             arrow_meta,
             geo_meta,
@@ -134,50 +148,16 @@ impl Reader {
         &self.geo_meta.primary_column
     }
 
-    pub fn geometry_overviews(&self) -> &[GeometryOverview] {
-        &self.cogp_meta.geometry_overviews
-    }
-
-    /// Select the first overview whose spatial tolerance is no coarser than
-    /// the target and whose non-null boundary covers the selected feature
-    /// prefix. Line and Polygon streaming stay on the finest complete overview
-    /// when the target is finer than every overview, avoiding the raw WKB
-    /// column. Point geometry retains the lossless primary-column fallback.
-    pub fn geometry_column_for_gsd(&self, target_gsd: f64) -> &str {
-        let minimum_level = self
+    /// Select the geometry representation declared by the level appropriate
+    /// for the target ground resolution.
+    pub fn geometry_column_for_resolution(&self, target_resolution_meters: f64) -> &str {
+        let level = self
             .cogp_meta
             .levels
             .iter()
-            .rposition(|level| level.gsd >= target_gsd)
+            .rposition(|level| level.resolution_meters >= target_resolution_meters)
             .unwrap_or(0);
-        let precise = self.cogp_meta.geometry_overviews.iter().find(|overview| {
-            overview.level >= minimum_level && overview.tolerance_meters <= target_gsd
-        });
-        if let Some(overview) = precise {
-            return &overview.column;
-        }
-        if self.primary_geometry_is_extended() {
-            if let Some(overview) = self
-                .cogp_meta
-                .geometry_overviews
-                .iter()
-                .rev()
-                .find(|overview| overview.level >= minimum_level)
-            {
-                return &overview.column;
-            }
-        }
-        &self.geo_meta.primary_column
-    }
-
-    fn primary_geometry_is_extended(&self) -> bool {
-        let Some(column) = self.geo_meta.columns.get(&self.geo_meta.primary_column) else {
-            return false;
-        };
-        matches!(
-            geometry_family(&column.geometry_types),
-            Some(GeometryFamily::Line | GeometryFamily::Polygon)
-        )
+        &self.cogp_meta.levels[level].geometry_column
     }
 
     pub fn num_row_groups(&self) -> usize {
@@ -210,12 +190,16 @@ impl Reader {
         0..(self.cogp_meta.levels[i].row_group_end + 1) as usize
     }
 
-    /// Row groups for every level whose GSD is `>= min_gsd` (coarser than the
+    /// Row groups for every level whose resolution is `>= target` (coarser than the
     /// caller's target resolution). Use this when you have a target ground
     /// resolution (e.g. screen meters/pixel) and want every level that's
     /// still useful at that scale, plus all coarser overviews.
-    pub fn row_groups_up_to_gsd(&self, min_gsd: f64) -> Range<usize> {
-        let last = self.cogp_meta.levels.iter().rposition(|l| l.gsd >= min_gsd);
+    pub fn row_groups_up_to_resolution(&self, target_resolution_meters: f64) -> Range<usize> {
+        let last = self
+            .cogp_meta
+            .levels
+            .iter()
+            .rposition(|level| level.resolution_meters >= target_resolution_meters);
         match last {
             Some(i) => 0..(self.cogp_meta.levels[i].row_group_end + 1) as usize,
             None => 0..0,
@@ -305,7 +289,7 @@ impl Reader {
     /// `AsyncFileReader`, reusing the cached footer metadata. The Parquet
     /// reader fetches only the byte ranges for the selected row groups, so
     /// pairing this with [`Self::row_groups_intersecting_bbox`] and/or
-    /// [`Self::row_groups_up_to_gsd`] gives you a near-minimal remote read.
+    /// [`Self::row_groups_up_to_resolution`] gives you a near-minimal remote read.
     #[cfg(feature = "async")]
     pub fn async_batch_stream<R: AsyncFileReader + Send + 'static>(
         &self,
@@ -352,19 +336,19 @@ mod tests {
     use parquet::file::metadata::KeyValue;
     use std::collections::BTreeMap;
 
-    fn level(row_group_end: i64, gsd: f64) -> Level {
-        Level { row_group_end, gsd }
+    fn level(row_group_end: i64, resolution_meters: f64) -> Level {
+        Level {
+            row_group_end,
+            resolution_meters,
+            geometry_column: "geometry".into(),
+        }
     }
 
     /// Construct a `Reader` whose footer carries the supplied COGP levels.
     /// The Arrow schema and row-group count are minimal — only the selector
     /// tests below read them. The construction path itself goes through the
     /// real `from_arrow_metadata`, so the metadata-parse code runs as well.
-    fn reader_with_metadata(
-        levels: Vec<Level>,
-        geometry_overviews: Vec<GeometryOverview>,
-        geometry_types: Vec<String>,
-    ) -> Reader {
+    fn reader_with_metadata(levels: Vec<Level>, geometry_types: Vec<String>) -> Reader {
         let schema = Arc::new(Schema::new(vec![Field::new("v", DataType::Int32, false)]));
         let mut buf: Vec<u8> = Vec::new();
         {
@@ -387,6 +371,11 @@ mod tests {
                     crs: None,
                 },
             );
+            let level_geometry = cols["geometry"].clone();
+            for level in &levels {
+                cols.entry(level.geometry_column.clone())
+                    .or_insert_with(|| level_geometry.clone());
+            }
             let geo = GeoMeta {
                 version: GEOPARQUET_VERSION.into(),
                 primary_column: "geometry".into(),
@@ -395,7 +384,6 @@ mod tests {
             let cogp = CogpMeta {
                 version: COGP_VERSION.into(),
                 levels,
-                geometry_overviews,
             };
             w.append_key_value_metadata(KeyValue {
                 key: GEO_METADATA_KEY.into(),
@@ -411,7 +399,7 @@ mod tests {
     }
 
     fn reader_with_levels(levels: Vec<Level>) -> Reader {
-        reader_with_metadata(levels, vec![], vec!["Point".into()])
+        reader_with_metadata(levels, vec!["Point".into()])
     }
 
     #[test]
@@ -440,75 +428,29 @@ mod tests {
     }
 
     #[test]
-    fn row_groups_up_to_gsd_picks_last_level_above_target() {
+    fn row_groups_up_to_resolution_picks_last_level_above_target() {
         let r = reader_with_levels(vec![level(1, 1000.0), level(4, 100.0), level(9, 10.0)]);
         // target finer than every level → include every level
-        assert_eq!(r.row_groups_up_to_gsd(1.0), 0..10);
-        // target equal to the finest level GSD → include every level
-        assert_eq!(r.row_groups_up_to_gsd(10.0), 0..10);
+        assert_eq!(r.row_groups_up_to_resolution(1.0), 0..10);
+        // target equal to the finest level resolution → include every level
+        assert_eq!(r.row_groups_up_to_resolution(10.0), 0..10);
         // target between levels 1 and 2 → cut off after level 1
-        assert_eq!(r.row_groups_up_to_gsd(50.0), 0..5);
+        assert_eq!(r.row_groups_up_to_resolution(50.0), 0..5);
         // target finer than the coarsest only
-        assert_eq!(r.row_groups_up_to_gsd(500.0), 0..2);
+        assert_eq!(r.row_groups_up_to_resolution(500.0), 0..2);
         // target coarser than every level → empty
-        assert!(r.row_groups_up_to_gsd(1e9).is_empty());
+        assert!(r.row_groups_up_to_resolution(1e9).is_empty());
     }
 
     #[test]
-    fn point_geometry_uses_raw_fallback_beyond_the_finest_overview() {
-        let r = reader_with_metadata(
-            vec![level(1, 1000.0), level(4, 100.0), level(9, 10.0)],
-            vec![
-                GeometryOverview {
-                    column: "geometry_ovr_0".into(),
-                    level: 0,
-                    tolerance_meters: 250.0,
-                },
-                GeometryOverview {
-                    column: "geometry_ovr_1".into(),
-                    level: 2,
-                    tolerance_meters: 25.0,
-                },
-            ],
-            vec!["Point".into()],
-        );
-        assert_eq!(r.geometry_column_for_gsd(1000.0), "geometry_ovr_0");
-        assert_eq!(r.geometry_column_for_gsd(50.0), "geometry_ovr_1");
-        assert_eq!(r.geometry_column_for_gsd(1.0), "geometry");
-    }
-
-    #[test]
-    fn line_geometry_column_never_falls_back_to_raw_for_streaming() {
-        let r = reader_with_metadata(
-            vec![level(1, 1000.0), level(4, 100.0), level(9, 10.0)],
-            vec![
-                GeometryOverview {
-                    column: "geometry_ovr_0".into(),
-                    level: 1,
-                    tolerance_meters: 250.0,
-                },
-                GeometryOverview {
-                    column: "geometry_ovr_1".into(),
-                    level: 2,
-                    tolerance_meters: 25.0,
-                },
-            ],
-            vec!["LineString".into(), "MultiLineString Z".into()],
-        );
-        assert_eq!(r.geometry_column_for_gsd(50.0), "geometry_ovr_1");
-        assert_eq!(r.geometry_column_for_gsd(1.0), "geometry_ovr_1");
-    }
-
-    #[test]
-    fn extended_geometry_without_overviews_uses_raw_geometry() {
-        for geometry_types in [vec!["LineString".into()], vec!["Polygon".into()]] {
-            let r = reader_with_metadata(
-                vec![level(1, 1000.0), level(4, 100.0)],
-                vec![],
-                geometry_types,
-            );
-            assert_eq!(r.geometry_column_for_gsd(1.0), "geometry");
-        }
+    fn geometry_column_comes_from_selected_level() {
+        let mut levels = vec![level(1, 1000.0), level(4, 100.0), level(9, 10.0)];
+        levels[0].geometry_column = "geometry_ovr_0".into();
+        levels[1].geometry_column = "geometry_ovr_1".into();
+        let r = reader_with_metadata(levels, vec!["LineString".into()]);
+        assert_eq!(r.geometry_column_for_resolution(1000.0), "geometry_ovr_0");
+        assert_eq!(r.geometry_column_for_resolution(50.0), "geometry_ovr_1");
+        assert_eq!(r.geometry_column_for_resolution(1.0), "geometry");
     }
 
     /// Build a tiny parquet `bytes::Bytes` blob with the given KV metadata
@@ -529,7 +471,6 @@ mod tests {
         let cogp = CogpMeta {
             version: COGP_VERSION.into(),
             levels: vec![],
-            geometry_overviews: vec![],
         };
         let err = try_open_with_kv(vec![KeyValue {
             key: COGP_METADATA_KEY.into(),

--- a/cogp-rs/src/reader.rs
+++ b/cogp-rs/src/reader.rs
@@ -20,7 +20,7 @@
 //! Geometries stay in their on-disk WKB form in the returned
 //! [`arrow_array::RecordBatch`]es; downstream callers convert them via
 //! [`geozero`](https://crates.io/crates/geozero) — see the README.
-use anyhow::{anyhow, Context, Result};
+use anyhow::{anyhow, bail, Context, Result};
 use parquet::arrow::arrow_reader::{
     ArrowReaderMetadata, ParquetRecordBatchReader, ParquetRecordBatchReaderBuilder,
 };
@@ -43,7 +43,10 @@ pub use parquet::arrow::async_reader::ParquetObjectReader;
 #[cfg(feature = "async")]
 pub use crate::range_coalescing::{RangeCoalescingOptions, RangeCoalescingReader};
 
-use crate::meta::{CogpMeta, GeoMeta, Level, COGP_METADATA_KEY, GEO_METADATA_KEY};
+use crate::meta::{
+    geometry_family, CogpMeta, GeoMeta, GeometryFamily, GeometryOverview, Level, COGP_METADATA_KEY,
+    GEO_METADATA_KEY,
+};
 
 /// Cached COGP file handle. Holds the parsed footer + COGP/GeoParquet metadata.
 /// Cheap to clone (the underlying `ArrowReaderMetadata` is `Arc`-backed) and
@@ -88,6 +91,18 @@ impl Reader {
     /// S3) and wants to skip even the initial range request.
     pub fn from_arrow_metadata(arrow_meta: ArrowReaderMetadata) -> Result<Self> {
         let (geo_meta, cogp_meta) = parse_cogp_kv(arrow_meta.metadata())?;
+        let primary = geo_meta
+            .columns
+            .get(&geo_meta.primary_column)
+            .ok_or_else(|| {
+                anyhow!(
+                    "`geo.columns` is missing primary_column `{}`",
+                    geo_meta.primary_column
+                )
+            })?;
+        if geometry_family(&primary.geometry_types).is_none() {
+            bail!("COGP primary geometry must declare exactly one Point, Line, or Polygon family");
+        }
         Ok(Self {
             arrow_meta,
             geo_meta,
@@ -117,6 +132,52 @@ impl Reader {
 
     pub fn primary_column(&self) -> &str {
         &self.geo_meta.primary_column
+    }
+
+    pub fn geometry_overviews(&self) -> &[GeometryOverview] {
+        &self.cogp_meta.geometry_overviews
+    }
+
+    /// Select the first overview whose spatial tolerance is no coarser than
+    /// the target and whose non-null boundary covers the selected feature
+    /// prefix. Line and Polygon streaming stay on the finest complete overview
+    /// when the target is finer than every overview, avoiding the raw WKB
+    /// column. Point geometry retains the lossless primary-column fallback.
+    pub fn geometry_column_for_gsd(&self, target_gsd: f64) -> &str {
+        let minimum_level = self
+            .cogp_meta
+            .levels
+            .iter()
+            .rposition(|level| level.gsd >= target_gsd)
+            .unwrap_or(0);
+        let precise = self.cogp_meta.geometry_overviews.iter().find(|overview| {
+            overview.level >= minimum_level && overview.tolerance_meters <= target_gsd
+        });
+        if let Some(overview) = precise {
+            return &overview.column;
+        }
+        if self.primary_geometry_is_extended() {
+            if let Some(overview) = self
+                .cogp_meta
+                .geometry_overviews
+                .iter()
+                .rev()
+                .find(|overview| overview.level >= minimum_level)
+            {
+                return &overview.column;
+            }
+        }
+        &self.geo_meta.primary_column
+    }
+
+    fn primary_geometry_is_extended(&self) -> bool {
+        let Some(column) = self.geo_meta.columns.get(&self.geo_meta.primary_column) else {
+            return false;
+        };
+        matches!(
+            geometry_family(&column.geometry_types),
+            Some(GeometryFamily::Line | GeometryFamily::Polygon)
+        )
     }
 
     pub fn num_row_groups(&self) -> usize {
@@ -299,7 +360,11 @@ mod tests {
     /// The Arrow schema and row-group count are minimal — only the selector
     /// tests below read them. The construction path itself goes through the
     /// real `from_arrow_metadata`, so the metadata-parse code runs as well.
-    fn reader_with_levels(levels: Vec<Level>) -> Reader {
+    fn reader_with_metadata(
+        levels: Vec<Level>,
+        geometry_overviews: Vec<GeometryOverview>,
+        geometry_types: Vec<String>,
+    ) -> Reader {
         let schema = Arc::new(Schema::new(vec![Field::new("v", DataType::Int32, false)]));
         let mut buf: Vec<u8> = Vec::new();
         {
@@ -309,7 +374,7 @@ mod tests {
                 "geometry".to_string(),
                 GeoColumn {
                     encoding: "WKB".into(),
-                    geometry_types: vec![],
+                    geometry_types,
                     covering: Some(Covering {
                         bbox: BboxCovering {
                             xmin: vec!["bbox".into(), "xmin".into()],
@@ -330,6 +395,7 @@ mod tests {
             let cogp = CogpMeta {
                 version: COGP_VERSION.into(),
                 levels,
+                geometry_overviews,
             };
             w.append_key_value_metadata(KeyValue {
                 key: GEO_METADATA_KEY.into(),
@@ -342,6 +408,10 @@ mod tests {
             w.close().unwrap();
         }
         Reader::try_new(bytes::Bytes::from(buf)).unwrap()
+    }
+
+    fn reader_with_levels(levels: Vec<Level>) -> Reader {
+        reader_with_metadata(levels, vec![], vec!["Point".into()])
     }
 
     #[test]
@@ -384,6 +454,63 @@ mod tests {
         assert!(r.row_groups_up_to_gsd(1e9).is_empty());
     }
 
+    #[test]
+    fn point_geometry_uses_raw_fallback_beyond_the_finest_overview() {
+        let r = reader_with_metadata(
+            vec![level(1, 1000.0), level(4, 100.0), level(9, 10.0)],
+            vec![
+                GeometryOverview {
+                    column: "geometry_ovr_0".into(),
+                    level: 0,
+                    tolerance_meters: 250.0,
+                },
+                GeometryOverview {
+                    column: "geometry_ovr_1".into(),
+                    level: 2,
+                    tolerance_meters: 25.0,
+                },
+            ],
+            vec!["Point".into()],
+        );
+        assert_eq!(r.geometry_column_for_gsd(1000.0), "geometry_ovr_0");
+        assert_eq!(r.geometry_column_for_gsd(50.0), "geometry_ovr_1");
+        assert_eq!(r.geometry_column_for_gsd(1.0), "geometry");
+    }
+
+    #[test]
+    fn line_geometry_column_never_falls_back_to_raw_for_streaming() {
+        let r = reader_with_metadata(
+            vec![level(1, 1000.0), level(4, 100.0), level(9, 10.0)],
+            vec![
+                GeometryOverview {
+                    column: "geometry_ovr_0".into(),
+                    level: 1,
+                    tolerance_meters: 250.0,
+                },
+                GeometryOverview {
+                    column: "geometry_ovr_1".into(),
+                    level: 2,
+                    tolerance_meters: 25.0,
+                },
+            ],
+            vec!["LineString".into(), "MultiLineString Z".into()],
+        );
+        assert_eq!(r.geometry_column_for_gsd(50.0), "geometry_ovr_1");
+        assert_eq!(r.geometry_column_for_gsd(1.0), "geometry_ovr_1");
+    }
+
+    #[test]
+    fn extended_geometry_without_overviews_uses_raw_geometry() {
+        for geometry_types in [vec!["LineString".into()], vec!["Polygon".into()]] {
+            let r = reader_with_metadata(
+                vec![level(1, 1000.0), level(4, 100.0)],
+                vec![],
+                geometry_types,
+            );
+            assert_eq!(r.geometry_column_for_gsd(1.0), "geometry");
+        }
+    }
+
     /// Build a tiny parquet `bytes::Bytes` blob with the given KV metadata
     /// entries and return the reader-construction result.
     fn try_open_with_kv(kv: Vec<KeyValue>) -> Result<Reader> {
@@ -402,6 +529,7 @@ mod tests {
         let cogp = CogpMeta {
             version: COGP_VERSION.into(),
             levels: vec![],
+            geometry_overviews: vec![],
         };
         let err = try_open_with_kv(vec![KeyValue {
             key: COGP_METADATA_KEY.into(),

--- a/cogp-rs/src/validate.rs
+++ b/cogp-rs/src/validate.rs
@@ -1,7 +1,7 @@
 use anyhow::{bail, Context, Result};
 use parquet::file::reader::{FileReader, SerializedFileReader};
 use parquet::file::statistics::Statistics;
-use std::collections::HashSet;
+use std::collections::HashMap;
 use std::fs::File;
 use std::path::Path;
 
@@ -125,7 +125,8 @@ pub fn run(path: &Path) -> Result<()> {
     }
 
     let mut prev_rge: Option<i64> = None;
-    let mut prev_gsd: Option<f64> = None;
+    let mut prev_resolution: Option<f64> = None;
+    let mut geometry_boundaries: HashMap<&str, i64> = HashMap::new();
     for (i, level) in cogp.levels.iter().enumerate() {
         if level.row_group_end < 0 || (level.row_group_end as usize) >= num_rgs {
             errors.push(format!(
@@ -142,19 +143,32 @@ pub fn run(path: &Path) -> Result<()> {
             }
         }
         prev_rge = Some(level.row_group_end);
-        // partial_cmp so NaN gsd values also fall into the error branch.
-        if level.gsd.partial_cmp(&0.0) != Some(std::cmp::Ordering::Greater) {
-            errors.push(format!("levels[{i}].gsd={} must be positive", level.gsd));
+        // partial_cmp so NaN values also fall into the error branch.
+        if level.resolution_meters.partial_cmp(&0.0) != Some(std::cmp::Ordering::Greater) {
+            errors.push(format!(
+                "levels[{i}].resolution_meters={} must be positive",
+                level.resolution_meters
+            ));
         }
-        if let Some(p) = prev_gsd {
-            if level.gsd.partial_cmp(&p) != Some(std::cmp::Ordering::Less) {
+        if let Some(previous) = prev_resolution {
+            if level.resolution_meters.partial_cmp(&previous) != Some(std::cmp::Ordering::Less) {
                 errors.push(format!(
-                    "levels[{i}].gsd={} must be strictly less than previous ({})",
-                    level.gsd, p
+                    "levels[{i}].resolution_meters={} must be strictly less than previous ({previous})",
+                    level.resolution_meters
                 ));
             }
         }
-        prev_gsd = Some(level.gsd);
+        prev_resolution = Some(level.resolution_meters);
+        if level.geometry_column.is_empty() {
+            errors.push(format!(
+                "levels[{i}].geometry_column must be a non-empty string"
+            ));
+        } else {
+            geometry_boundaries
+                .entry(&level.geometry_column)
+                .and_modify(|boundary| *boundary = (*boundary).max(level.row_group_end))
+                .or_insert(level.row_group_end);
+        }
     }
     if let Some(last) = cogp.levels.last() {
         if num_rgs > 0 && last.row_group_end != (num_rgs as i64) - 1 {
@@ -167,84 +181,44 @@ pub fn run(path: &Path) -> Result<()> {
     }
 
     let parquet_schema = metadata.file_metadata().schema_descr();
-    let mut overview_names = HashSet::new();
-    let mut previous_overview_level: Option<usize> = None;
-    let mut previous_overview_tolerance: Option<f64> = None;
-    for (index, overview) in cogp.geometry_overviews.iter().enumerate() {
-        if !overview_names.insert(overview.column.as_str()) {
-            errors.push(format!(
-                "geometry_overviews[{index}].column=`{}` is duplicated",
-                overview.column
-            ));
-        }
-        if let Some(previous) = previous_overview_level {
-            if overview.level <= previous {
-                errors.push(format!(
-                    "geometry_overviews[{index}].level={} must be greater than previous ({previous})",
-                    overview.level
-                ));
-            }
-        }
-        previous_overview_level = Some(overview.level);
-        if overview.tolerance_meters.partial_cmp(&0.0) != Some(std::cmp::Ordering::Greater) {
-            errors.push(format!(
-                "geometry_overviews[{index}].tolerance_meters={} must be positive",
-                overview.tolerance_meters
-            ));
-        }
-        if let Some(previous) = previous_overview_tolerance {
-            if overview.tolerance_meters.partial_cmp(&previous) != Some(std::cmp::Ordering::Less) {
-                errors.push(format!(
-                    "geometry_overviews[{index}].tolerance_meters={} must be less than previous ({previous})",
-                    overview.tolerance_meters
-                ));
-            }
-        }
-        previous_overview_tolerance = Some(overview.tolerance_meters);
-
-        let Some(level) = cogp.levels.get(overview.level) else {
-            errors.push(format!(
-                "geometry_overviews[{index}].level={} is out of range",
-                overview.level
-            ));
-            continue;
-        };
-        match geo.columns.get(&overview.column) {
+    for (geometry_column, boundary) in geometry_boundaries {
+        match geo.columns.get(geometry_column) {
             Some(column) if column.encoding == "WKB" => {}
             Some(column) => errors.push(format!(
-                "geometry overview `{}` must have GeoParquet WKB encoding, got `{}`",
-                overview.column, column.encoding
+                "level geometry column `{geometry_column}` must have GeoParquet WKB encoding, got `{}`",
+                column.encoding
             )),
             None => errors.push(format!(
-                "geometry overview `{}` is missing from `geo.columns`",
-                overview.column
+                "level geometry column `{geometry_column}` is missing from `geo.columns`"
             )),
         }
 
         let parquet_column = (0..parquet_schema.num_columns()).find(|column_index| {
-            parquet_schema.column(*column_index).path().string() == overview.column
+            parquet_schema.column(*column_index).path().string() == geometry_column
         });
         let Some(parquet_column) = parquet_column else {
             errors.push(format!(
-                "geometry overview `{}` is missing from the Parquet schema",
-                overview.column
+                "level geometry column `{geometry_column}` is missing from the Parquet schema"
             ));
             continue;
         };
-        if !parquet_schema
-            .column(parquet_column)
-            .self_type()
-            .is_optional()
+        if geometry_column != primary
+            && !parquet_schema
+                .column(parquet_column)
+                .self_type()
+                .is_optional()
         {
             errors.push(format!(
-                "geometry overview `{}` must be nullable in the Parquet schema",
-                overview.column
+                "non-primary level geometry column `{geometry_column}` must be nullable in the Parquet schema"
             ));
         }
 
+        if geometry_column == primary {
+            continue;
+        }
         for row_group_index in 0..num_rgs {
             let row_group = metadata.row_group(row_group_index);
-            let expected_nulls = if (row_group_index as i64) <= level.row_group_end {
+            let expected_nulls = if (row_group_index as i64) <= boundary {
                 0
             } else {
                 row_group.num_rows() as u64
@@ -256,27 +230,14 @@ pub fn run(path: &Path) -> Result<()> {
             if let Some(actual_nulls) = actual_nulls {
                 if actual_nulls != expected_nulls {
                     errors.push(format!(
-                        "row group {row_group_index} geometry overview `{}` has {actual_nulls} null(s), expected {expected_nulls}",
-                        overview.column
+                        "row group {row_group_index} level geometry column `{geometry_column}` has {actual_nulls} null(s), expected {expected_nulls}"
                     ));
                 }
             } else {
                 warnings.push(format!(
-                    "row group {row_group_index} geometry overview `{}` has no null-count statistics; sparse boundary was not verified",
-                    overview.column
+                    "row group {row_group_index} level geometry column `{geometry_column}` has no null-count statistics; sparse boundary was not verified"
                 ));
             }
-        }
-    }
-    if let (Some(final_overview), Some(final_level_index)) = (
-        cogp.geometry_overviews.last(),
-        cogp.levels.len().checked_sub(1),
-    ) {
-        if final_overview.level != final_level_index {
-            errors.push(format!(
-                "final geometry overview level={} must equal final level index={final_level_index}",
-                final_overview.level
-            ));
         }
     }
 

--- a/cogp-rs/src/validate.rs
+++ b/cogp-rs/src/validate.rs
@@ -1,10 +1,13 @@
 use anyhow::{bail, Context, Result};
 use parquet::file::reader::{FileReader, SerializedFileReader};
 use parquet::file::statistics::Statistics;
+use std::collections::HashSet;
 use std::fs::File;
 use std::path::Path;
 
-use crate::meta::{CogpMeta, GeoMeta, COGP_METADATA_KEY, GEO_METADATA_KEY};
+use crate::meta::{
+    geometry_family, CogpMeta, GeoMeta, COGP_METADATA_KEY, COGP_VERSION, GEO_METADATA_KEY,
+};
 
 pub fn run(path: &Path) -> Result<()> {
     let file = File::open(path).with_context(|| format!("opening {}", path.display()))?;
@@ -49,23 +52,35 @@ pub fn run(path: &Path) -> Result<()> {
         }
     };
     if !geo.version.starts_with("1.") {
-        warnings.push(format!("GeoParquet version is `{}`; COGP v0.1 targets 1.1.x", geo.version));
+        warnings.push(format!(
+            "GeoParquet version is `{}`; COGP {COGP_VERSION} targets 1.1.x",
+            geo.version
+        ));
     }
 
     let primary = geo.primary_column.clone();
     let primary_col = match geo.columns.get(&primary) {
         Some(c) => c.clone(),
         None => {
-            errors.push(format!("`geo.columns` is missing primary_column `{primary}`"));
+            errors.push(format!(
+                "`geo.columns` is missing primary_column `{primary}`"
+            ));
             print_report(path, &errors, &warnings);
             bail!("validation failed");
         }
     };
+    if geometry_family(&primary_col.geometry_types).is_none() {
+        errors.push(format!(
+            "`geo.columns[{primary}].geometry_types` must declare exactly one Point, Line, or Polygon family"
+        ));
+    }
 
     let covering = match primary_col.covering.as_ref() {
         Some(c) => c,
         None => {
-            errors.push(format!("`geo.columns[{primary}].covering` is required by COGP §5.1"));
+            errors.push(format!(
+                "`geo.columns[{primary}].covering` is required by COGP §5.1"
+            ));
             print_report(path, &errors, &warnings);
             bail!("validation failed");
         }
@@ -88,9 +103,17 @@ pub fn run(path: &Path) -> Result<()> {
         }
     };
 
-    let major: u32 = cogp.version.split('.').next().and_then(|s| s.parse().ok()).unwrap_or(0);
+    let major: u32 = cogp
+        .version
+        .split('.')
+        .next()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(0);
     if major != 0 {
-        errors.push(format!("unsupported cogp major version `{}`; this validator implements 0.x", cogp.version));
+        errors.push(format!(
+            "unsupported cogp major version `{}`; this validator implements 0.x",
+            cogp.version
+        ));
     }
     if cogp.levels.is_empty() {
         errors.push("`cogp.levels` must be non-empty".into());
@@ -143,6 +166,120 @@ pub fn run(path: &Path) -> Result<()> {
         }
     }
 
+    let parquet_schema = metadata.file_metadata().schema_descr();
+    let mut overview_names = HashSet::new();
+    let mut previous_overview_level: Option<usize> = None;
+    let mut previous_overview_tolerance: Option<f64> = None;
+    for (index, overview) in cogp.geometry_overviews.iter().enumerate() {
+        if !overview_names.insert(overview.column.as_str()) {
+            errors.push(format!(
+                "geometry_overviews[{index}].column=`{}` is duplicated",
+                overview.column
+            ));
+        }
+        if let Some(previous) = previous_overview_level {
+            if overview.level <= previous {
+                errors.push(format!(
+                    "geometry_overviews[{index}].level={} must be greater than previous ({previous})",
+                    overview.level
+                ));
+            }
+        }
+        previous_overview_level = Some(overview.level);
+        if overview.tolerance_meters.partial_cmp(&0.0) != Some(std::cmp::Ordering::Greater) {
+            errors.push(format!(
+                "geometry_overviews[{index}].tolerance_meters={} must be positive",
+                overview.tolerance_meters
+            ));
+        }
+        if let Some(previous) = previous_overview_tolerance {
+            if overview.tolerance_meters.partial_cmp(&previous) != Some(std::cmp::Ordering::Less) {
+                errors.push(format!(
+                    "geometry_overviews[{index}].tolerance_meters={} must be less than previous ({previous})",
+                    overview.tolerance_meters
+                ));
+            }
+        }
+        previous_overview_tolerance = Some(overview.tolerance_meters);
+
+        let Some(level) = cogp.levels.get(overview.level) else {
+            errors.push(format!(
+                "geometry_overviews[{index}].level={} is out of range",
+                overview.level
+            ));
+            continue;
+        };
+        match geo.columns.get(&overview.column) {
+            Some(column) if column.encoding == "WKB" => {}
+            Some(column) => errors.push(format!(
+                "geometry overview `{}` must have GeoParquet WKB encoding, got `{}`",
+                overview.column, column.encoding
+            )),
+            None => errors.push(format!(
+                "geometry overview `{}` is missing from `geo.columns`",
+                overview.column
+            )),
+        }
+
+        let parquet_column = (0..parquet_schema.num_columns()).find(|column_index| {
+            parquet_schema.column(*column_index).path().string() == overview.column
+        });
+        let Some(parquet_column) = parquet_column else {
+            errors.push(format!(
+                "geometry overview `{}` is missing from the Parquet schema",
+                overview.column
+            ));
+            continue;
+        };
+        if !parquet_schema
+            .column(parquet_column)
+            .self_type()
+            .is_optional()
+        {
+            errors.push(format!(
+                "geometry overview `{}` must be nullable in the Parquet schema",
+                overview.column
+            ));
+        }
+
+        for row_group_index in 0..num_rgs {
+            let row_group = metadata.row_group(row_group_index);
+            let expected_nulls = if (row_group_index as i64) <= level.row_group_end {
+                0
+            } else {
+                row_group.num_rows() as u64
+            };
+            let actual_nulls = row_group
+                .column(parquet_column)
+                .statistics()
+                .and_then(Statistics::null_count_opt);
+            if let Some(actual_nulls) = actual_nulls {
+                if actual_nulls != expected_nulls {
+                    errors.push(format!(
+                        "row group {row_group_index} geometry overview `{}` has {actual_nulls} null(s), expected {expected_nulls}",
+                        overview.column
+                    ));
+                }
+            } else {
+                warnings.push(format!(
+                    "row group {row_group_index} geometry overview `{}` has no null-count statistics; sparse boundary was not verified",
+                    overview.column
+                ));
+            }
+        }
+    }
+    if let (Some(final_overview), Some(final_level_index)) = (
+        cogp.geometry_overviews.last(),
+        cogp.levels.len().checked_sub(1),
+    ) {
+        if final_overview.level != final_level_index {
+            errors.push(format!(
+                "final geometry overview level={} must equal final level index={final_level_index}",
+                final_overview.level
+            ));
+        }
+    }
+
     // §5.1 cont: bbox covering columns must have row group min/max stats.
     // Locate the column indexes for each bbox sub-field.
     let schema = file_meta.schema_descr();
@@ -163,14 +300,30 @@ pub fn run(path: &Path) -> Result<()> {
                     match col.statistics() {
                         Some(stats) => {
                             let has_min_max = match stats {
-                                Statistics::Boolean(s) => s.min_bytes_opt().is_some() && s.max_bytes_opt().is_some(),
-                                Statistics::Int32(s) => s.min_bytes_opt().is_some() && s.max_bytes_opt().is_some(),
-                                Statistics::Int64(s) => s.min_bytes_opt().is_some() && s.max_bytes_opt().is_some(),
-                                Statistics::Int96(s) => s.min_bytes_opt().is_some() && s.max_bytes_opt().is_some(),
-                                Statistics::Float(s) => s.min_bytes_opt().is_some() && s.max_bytes_opt().is_some(),
-                                Statistics::Double(s) => s.min_bytes_opt().is_some() && s.max_bytes_opt().is_some(),
-                                Statistics::ByteArray(s) => s.min_bytes_opt().is_some() && s.max_bytes_opt().is_some(),
-                                Statistics::FixedLenByteArray(s) => s.min_bytes_opt().is_some() && s.max_bytes_opt().is_some(),
+                                Statistics::Boolean(s) => {
+                                    s.min_bytes_opt().is_some() && s.max_bytes_opt().is_some()
+                                }
+                                Statistics::Int32(s) => {
+                                    s.min_bytes_opt().is_some() && s.max_bytes_opt().is_some()
+                                }
+                                Statistics::Int64(s) => {
+                                    s.min_bytes_opt().is_some() && s.max_bytes_opt().is_some()
+                                }
+                                Statistics::Int96(s) => {
+                                    s.min_bytes_opt().is_some() && s.max_bytes_opt().is_some()
+                                }
+                                Statistics::Float(s) => {
+                                    s.min_bytes_opt().is_some() && s.max_bytes_opt().is_some()
+                                }
+                                Statistics::Double(s) => {
+                                    s.min_bytes_opt().is_some() && s.max_bytes_opt().is_some()
+                                }
+                                Statistics::ByteArray(s) => {
+                                    s.min_bytes_opt().is_some() && s.max_bytes_opt().is_some()
+                                }
+                                Statistics::FixedLenByteArray(s) => {
+                                    s.min_bytes_opt().is_some() && s.max_bytes_opt().is_some()
+                                }
                             };
                             if !has_min_max {
                                 errors.push(format!(
@@ -196,7 +349,7 @@ pub fn run(path: &Path) -> Result<()> {
 
 fn print_report(path: &Path, errors: &[String], warnings: &[String]) {
     if errors.is_empty() {
-        println!("OK: {} conforms to COGP v0.1", path.display());
+        println!("OK: {} conforms to COGP {COGP_VERSION}", path.display());
     } else {
         println!("FAIL: {} ({} error(s))", path.display(), errors.len());
     }

--- a/cogp-rs/src/wkb_simplify.rs
+++ b/cogp-rs/src/wkb_simplify.rs
@@ -5,11 +5,17 @@
 //! to a power-of-two grid no coarser than the tolerance so their f64 low bits
 //! compress well; Z/M ordinates remain lossless. Polygon rings keep their closure and minimum
 //! vertex count. A simplified line is viable only when its length exceeds the
-//! active tolerance. This local algorithm does not promise topology
-//! preservation across rings or neighboring features.
+//! active tolerance. Like Tippecanoe, polygons are simplified first and cleaned
+//! after coordinate quantization. No shared-edge topology is promised across
+//! neighboring features.
 
 use anyhow::{bail, Result};
 use byteorder::{BigEndian, ByteOrder, LittleEndian};
+use geo::{Coord, LineString, Polygon, Validation};
+use i_overlay::core::fill_rule::FillRule;
+use i_overlay::core::overlay::Overlay;
+use i_overlay::core::overlay_rule::OverlayRule;
+use i_overlay::i_float::int::point::IntPoint;
 
 #[derive(Clone)]
 struct Coordinate(Vec<f64>);
@@ -31,22 +37,14 @@ enum Body {
 }
 
 pub fn simplify_wkb(bytes: &[u8], tolerance: f64) -> Result<Vec<u8>> {
-    if !tolerance.is_finite() || tolerance <= 0.0 {
-        bail!("simplification tolerance must be positive and finite");
-    }
-    let mut offset = 0;
-    let mut geometry = parse_geometry(bytes, &mut offset)?;
-    if offset != bytes.len() {
-        bail!("trailing bytes after WKB geometry");
-    }
-    // A source feature must remain available at the finest level. If even the
-    // requested tolerance cannot form a valid geometry, retaining raw WKB is
-    // a lossless (zero-error) fallback. Level assignment prevents this fallback
-    // at coarser levels by deferring the feature until simplification survives.
-    if !simplify_geometry(&mut geometry, tolerance * tolerance) {
+    validate_tolerance(tolerance)?;
+    let geometry = parse_complete_geometry(bytes)?;
+    let OverviewOutcome::Built(geometry) = build_overview(&geometry, tolerance) else {
+        // Callers keep the source at the finest selected level when it cannot
+        // be represented safely. Coarser level selection uses the same outcome
+        // and therefore never selects a source-WKB fallback as an overview.
         return Ok(bytes.to_vec());
-    }
-    quantize_geometry(&mut geometry, quantization_grid(tolerance));
+    };
     let mut output = Vec::with_capacity(bytes.len());
     write_geometry(&geometry, &mut output);
     Ok(output)
@@ -59,21 +57,175 @@ pub fn first_viable_level(bytes: &[u8], tolerances: &[f64]) -> Result<usize> {
     if tolerances.is_empty() {
         bail!("simplification profile requires at least one tolerance");
     }
+    let geometry = parse_complete_geometry(bytes)?;
+    for (level, tolerance) in tolerances.iter().enumerate() {
+        validate_tolerance(*tolerance)?;
+        if matches!(
+            build_overview(&geometry, *tolerance),
+            OverviewOutcome::Built(_)
+        ) {
+            return Ok(level);
+        }
+    }
+    Ok(tolerances.len() - 1)
+}
+
+enum OverviewOutcome {
+    Built(Geometry),
+    NotViable,
+    PreserveSource,
+}
+
+fn validate_tolerance(tolerance: f64) -> Result<()> {
+    if !tolerance.is_finite() || tolerance <= 0.0 {
+        bail!("simplification tolerance must be positive and finite");
+    }
+    Ok(())
+}
+
+fn parse_complete_geometry(bytes: &[u8]) -> Result<Geometry> {
     let mut offset = 0;
     let geometry = parse_geometry(bytes, &mut offset)?;
     if offset != bytes.len() {
         bail!("trailing bytes after WKB geometry");
     }
-    for (level, tolerance) in tolerances.iter().enumerate() {
-        if !tolerance.is_finite() || *tolerance <= 0.0 {
-            bail!("simplification tolerance must be positive and finite");
+    Ok(geometry)
+}
+
+/// Build one overview using only the source geometry and requested tolerance.
+/// Keeping viability and materialization behind this interface prevents them
+/// from disagreeing about post-quantization polygon collapse.
+fn build_overview(source: &Geometry, tolerance: f64) -> OverviewOutcome {
+    let grid = quantization_grid(tolerance);
+    build_geometry(source, tolerance * tolerance, grid)
+}
+
+fn build_geometry(source: &Geometry, tolerance2: f64, grid: f64) -> OverviewOutcome {
+    if let Body::Collection(source_children) = &source.body {
+        let mut children = Vec::with_capacity(source_children.len());
+        for child in source_children {
+            match build_geometry(child, tolerance2, grid) {
+                OverviewOutcome::Built(child) => children.push(child),
+                OverviewOutcome::NotViable => {}
+                OverviewOutcome::PreserveSource => return OverviewOutcome::PreserveSource,
+            }
         }
-        let mut candidate = geometry.clone();
-        if simplify_geometry(&mut candidate, tolerance * tolerance) {
-            return Ok(level);
+        if children.is_empty() {
+            return OverviewOutcome::NotViable;
+        }
+        if geometry_kind(source.raw_type) == 6 {
+            children = flatten_multipolygon_children(children);
+        }
+        let mut geometry = source.clone();
+        geometry.body = Body::Collection(children);
+        return OverviewOutcome::Built(geometry);
+    }
+
+    // Retrying with smaller distance tolerances retains more source vertices
+    // without changing the output grid. The first failed viability check still
+    // defers the feature; retries are only for post-quantization cleaning loss.
+    const RETRY_TOLERANCE2_SCALES: [f64; 4] = [1.0, 0.25, 0.0625, 0.0];
+    for (attempt, scale) in RETRY_TOLERANCE2_SCALES.into_iter().enumerate() {
+        let mut candidate = source.clone();
+        if !simplify_geometry(&mut candidate, tolerance2 * scale) {
+            if attempt == 0 {
+                return OverviewOutcome::NotViable;
+            }
+            continue;
+        }
+        quantize_geometry(&mut candidate, grid);
+        let before_cleaning = candidate.clone();
+        if clean_geometry(&mut candidate, grid) {
+            return OverviewOutcome::Built(candidate);
+        }
+        if attempt == 0 {
+            if let Some(revived) = revive_tiny_polygon(&before_cleaning, source, grid) {
+                return OverviewOutcome::Built(revived);
+            }
         }
     }
-    Ok(tolerances.len() - 1)
+    OverviewOutcome::PreserveSource
+}
+
+fn flatten_multipolygon_children(children: Vec<Geometry>) -> Vec<Geometry> {
+    let mut flattened = Vec::with_capacity(children.len());
+    for child in children {
+        if geometry_kind(child.raw_type) == 6 {
+            if let Body::Collection(grandchildren) = child.body {
+                flattened.extend(grandchildren);
+            }
+        } else {
+            flattened.push(child);
+        }
+    }
+    flattened
+}
+
+/// Tippecanoe revives a polygon that disappears at tile precision as a small
+/// rectangle. Restrict that approximation to truly tiny XY polygons so a
+/// cleaning defect can never turn a substantial feature into a placeholder.
+fn revive_tiny_polygon(candidate: &Geometry, source: &Geometry, grid: f64) -> Option<Geometry> {
+    const MAX_AREA_IN_GRID_CELLS: f64 = 4.0;
+
+    let (Body::Polygon(candidate_rings), Body::Polygon(source_rings)) =
+        (&candidate.body, &source.body)
+    else {
+        return None;
+    };
+    if source_rings
+        .iter()
+        .flatten()
+        .any(|coordinate| coordinate.0.len() != 2)
+    {
+        return None;
+    }
+    let exterior_area2 = signed_area2(source_rings.first()?).abs();
+    let holes_area2: f64 = source_rings[1..]
+        .iter()
+        .map(|ring| signed_area2(ring).abs())
+        .sum();
+    let area_in_grid_cells = ((exterior_area2 - holes_area2).max(0.0) / 2.0) / (grid * grid);
+    if !area_in_grid_cells.is_finite()
+        || area_in_grid_cells <= 0.0
+        || area_in_grid_cells > MAX_AREA_IN_GRID_CELLS
+    {
+        return None;
+    }
+
+    let points: Vec<&Coordinate> = candidate_rings.iter().flatten().collect();
+    if points.is_empty() {
+        return None;
+    }
+    let center_x = points.iter().map(|point| point.0[0] / grid).sum::<f64>() / points.len() as f64;
+    let center_y = points.iter().map(|point| point.0[1] / grid).sum::<f64>() / points.len() as f64;
+    if !center_x.is_finite() || !center_y.is_finite() {
+        return None;
+    }
+
+    let height = area_in_grid_cells.sqrt().ceil().max(1.0);
+    let width = (area_in_grid_cells / height).round().max(1.0);
+    let x0 = center_x.round() - (width / 2.0).floor();
+    let y0 = center_y.round() - (height / 2.0).floor();
+    let x1 = x0 + width;
+    let y1 = y0 + height;
+    let coordinate = |x: f64, y: f64| {
+        let x = x * grid;
+        let y = y * grid;
+        Coordinate(vec![
+            if x == 0.0 { 0.0 } else { x },
+            if y == 0.0 { 0.0 } else { y },
+        ])
+    };
+    let ring = vec![
+        coordinate(x0, y0),
+        coordinate(x1, y0),
+        coordinate(x1, y1),
+        coordinate(x0, y1),
+        coordinate(x0, y0),
+    ];
+    let mut revived = source.clone();
+    revived.body = Body::Polygon(vec![ring]);
+    Some(revived)
 }
 
 /// Choose the largest power-of-two grid spacing no greater than the requested
@@ -141,7 +293,7 @@ fn simplify_geometry(geometry: &mut Geometry, tolerance2: f64) -> bool {
             let mut simplified = Vec::with_capacity(rings.len());
             simplified.push(exterior);
             // A collapsed interior ring is a sub-resolution hole, not a reason
-            // to discard an otherwise valid polygon.
+            // to discard an otherwise viable polygon.
             for ring in &rings[1..] {
                 if let Some(ring) = simplify_ring(ring, tolerance2) {
                     simplified.push(ring);
@@ -161,12 +313,208 @@ fn simplify_ring(ring: &[Coordinate], tolerance2: f64) -> Option<Vec<Coordinate>
     if ring.len() < 4 || !same_xy(&ring[0], ring.last()?) {
         return None;
     }
-    let mut simplified = simplify_line(&ring[..ring.len() - 1], tolerance2, 2);
-    if simplified.len() < 3 || signed_area2(&simplified) == 0.0 {
+    // Keep level visibility compatible with the existing profile: a ring that
+    // collapses below three unique vertices is deferred to a finer level.
+    let viability = simplify_line(&ring[..ring.len() - 1], tolerance2, 2);
+    if viability.len() < 3 || signed_area2(&viability) == 0.0 {
         return None;
     }
-    simplified.push(simplified[0].clone());
+
+    // Tippecanoe passes the duplicated closing point through Douglas-Peucker
+    // and forces four retained coordinates. Starting from the degenerate
+    // first-to-last segment avoids making an arbitrary ring edge the baseline.
+    let simplified = simplify_line(ring, tolerance2, 4);
+    if simplified.len() < 4
+        || !same_xy(&simplified[0], simplified.last()?)
+        || signed_area2(&simplified[..simplified.len() - 1]) == 0.0
+    {
+        return None;
+    }
     Some(simplified)
+}
+
+fn clean_geometry(geometry: &mut Geometry, grid: f64) -> bool {
+    match &mut geometry.body {
+        Body::Polygon(rings) => {
+            let Some(cleaned) = clean_polygon(rings, grid) else {
+                return false;
+            };
+            if let PolygonCleanResult::Split(polygons) = cleaned {
+                let child_raw_type = raw_type_with_kind(geometry.raw_type & !0x2000_0000, 3);
+                let children = polygons
+                    .into_iter()
+                    .map(|rings| Geometry {
+                        byte_order: geometry.byte_order,
+                        raw_type: child_raw_type,
+                        srid: None,
+                        body: Body::Polygon(rings),
+                    })
+                    .collect();
+                geometry.raw_type = raw_type_with_kind(geometry.raw_type, 6);
+                geometry.body = Body::Collection(children);
+            }
+            true
+        }
+        Body::Collection(children) => {
+            if !children.iter_mut().all(|child| clean_geometry(child, grid)) {
+                return false;
+            }
+            // A repaired Polygon can split into a MultiPolygon. Flatten it
+            // when it is already nested in a MultiPolygon WKB container.
+            if geometry_kind(geometry.raw_type) == 6 {
+                let mut flattened = Vec::with_capacity(children.len());
+                for child in std::mem::take(children) {
+                    if geometry_kind(child.raw_type) == 6 {
+                        let Body::Collection(grandchildren) = child.body else {
+                            return false;
+                        };
+                        flattened.extend(grandchildren);
+                    } else {
+                        flattened.push(child);
+                    }
+                }
+                *children = flattened;
+            }
+            true
+        }
+        Body::Point(_) | Body::LineString(_) => true,
+    }
+}
+
+enum PolygonCleanResult {
+    Unchanged,
+    Split(Vec<Vec<Vec<Coordinate>>>),
+}
+
+fn clean_polygon(rings: &mut Vec<Vec<Coordinate>>, grid: f64) -> Option<PolygonCleanResult> {
+    if rings
+        .iter()
+        .flatten()
+        .any(|coordinate| coordinate.0.len() != 2)
+    {
+        return polygon_xy(rings)
+            .is_valid()
+            .then_some(PolygonCleanResult::Unchanged);
+    }
+
+    // Tippecanoe cleans after scaling to integer tile coordinates. Do the same
+    // on our power-of-two overview grid so newly noded intersections cannot
+    // reintroduce arbitrary f64 low bits and defeat Parquet compression.
+    let grid_polygon = polygon_grid(rings, grid)?;
+    let mut overlay = Overlay::with_contours(&grid_polygon.contours, &[]);
+    overlay.options.ogc = true;
+    let cleaned = overlay.overlay(OverlayRule::Subject, FillRule::EvenOdd);
+    if cleaned.is_empty() {
+        return None;
+    }
+    if cleaned.len() == 1 {
+        *rings = polygon_coordinates(&cleaned[0], grid, &grid_polygon);
+        return Some(PolygonCleanResult::Unchanged);
+    }
+
+    Some(PolygonCleanResult::Split(
+        cleaned
+            .iter()
+            .map(|shape| polygon_coordinates(shape, grid, &grid_polygon))
+            .collect(),
+    ))
+}
+
+fn polygon_xy(rings: &[Vec<Coordinate>]) -> Polygon<f64> {
+    let exterior = rings
+        .first()
+        .map_or_else(|| LineString::new(Vec::new()), |ring| xy_line_string(ring));
+    Polygon::new(
+        exterior,
+        rings[1..].iter().map(|ring| xy_line_string(ring)).collect(),
+    )
+}
+
+struct GridPolygon {
+    contours: Vec<Vec<IntPoint>>,
+    origin_x: f64,
+    origin_y: f64,
+}
+
+fn polygon_grid(rings: &[Vec<Coordinate>], grid: f64) -> Option<GridPolygon> {
+    let origin = rings.first()?.first()?;
+    let origin_x = (origin.0[0] / grid).round();
+    let origin_y = (origin.0[1] / grid).round();
+    if !origin_x.is_finite() || !origin_y.is_finite() {
+        return None;
+    }
+    let convert = |ring: &[Coordinate]| {
+        let unclosed = if ring.len() >= 2 && same_xy(&ring[0], ring.last()?) {
+            &ring[..ring.len() - 1]
+        } else {
+            ring
+        };
+        unclosed
+            .iter()
+            .map(|coordinate| {
+                let x = coordinate.0[0] / grid - origin_x;
+                let y = coordinate.0[1] / grid - origin_y;
+                if !x.is_finite()
+                    || !y.is_finite()
+                    || x < i32::MIN as f64
+                    || x > i32::MAX as f64
+                    || y < i32::MIN as f64
+                    || y > i32::MAX as f64
+                {
+                    return None;
+                }
+                Some(IntPoint::new(x.round() as i32, y.round() as i32))
+            })
+            .collect::<Option<Vec<_>>>()
+    };
+    let contours = rings
+        .iter()
+        .map(|ring| convert(ring))
+        .collect::<Option<Vec<_>>>()?;
+    Some(GridPolygon {
+        contours,
+        origin_x,
+        origin_y,
+    })
+}
+
+fn polygon_coordinates(
+    shape: &[Vec<IntPoint>],
+    grid: f64,
+    grid_polygon: &GridPolygon,
+) -> Vec<Vec<Coordinate>> {
+    shape
+        .iter()
+        .map(|contour| {
+            let mut ring: Vec<Coordinate> = contour
+                .iter()
+                .map(|coordinate| {
+                    let x = (coordinate.x as f64 + grid_polygon.origin_x) * grid;
+                    let y = (coordinate.y as f64 + grid_polygon.origin_y) * grid;
+                    Coordinate(vec![
+                        if x == 0.0 { 0.0 } else { x },
+                        if y == 0.0 { 0.0 } else { y },
+                    ])
+                })
+                .collect();
+            if let Some(first) = ring.first().cloned() {
+                ring.push(first);
+            }
+            ring
+        })
+        .collect()
+}
+
+fn geometry_kind(raw_type: u32) -> u32 {
+    (raw_type & 0xffff) % 1000
+}
+
+fn raw_type_with_kind(raw_type: u32, kind: u32) -> u32 {
+    if raw_type & 0xe000_0000 != 0 {
+        (raw_type & 0xe000_0000) | kind
+    } else {
+        (raw_type / 1000) * 1000 + kind
+    }
 }
 
 fn signed_area2(points: &[Coordinate]) -> f64 {
@@ -198,9 +546,10 @@ fn simplify_line(points: &[Coordinate], tolerance2: f64, minimum: usize) -> Vec<
     let mut keep = vec![false; points.len()];
     keep[0] = true;
     keep[points.len() - 1] = true;
+    let mut retained = 2;
     let mut stack = vec![(0usize, points.len() - 1)];
     while let Some((start, end)) = stack.pop() {
-        let mut greatest_distance2 = tolerance2;
+        let mut greatest_distance2 = if retained < minimum { -1.0 } else { tolerance2 };
         let mut greatest_index = None;
         for index in start + 1..end {
             let distance2 = segment_distance2(&points[index], &points[start], &points[end]);
@@ -211,6 +560,7 @@ fn simplify_line(points: &[Coordinate], tolerance2: f64, minimum: usize) -> Vec<
         }
         if let Some(index) = greatest_index {
             keep[index] = true;
+            retained += 1;
             stack.push((start, index));
             stack.push((index, end));
         }
@@ -240,6 +590,18 @@ fn segment_distance2(point: &Coordinate, start: &Coordinate, end: &Coordinate) -
     (px - (ax + t * dx)).powi(2) + (py - (ay + t * dy)).powi(2)
 }
 
+fn xy_line_string(points: &[Coordinate]) -> LineString<f64> {
+    LineString::new(
+        points
+            .iter()
+            .map(|point| Coord {
+                x: point.0[0],
+                y: point.0[1],
+            })
+            .collect(),
+    )
+}
+
 fn same_xy(left: &Coordinate, right: &Coordinate) -> bool {
     left.0[0] == right.0[0] && left.0[1] == right.0[1]
 }
@@ -258,7 +620,7 @@ fn parse_geometry(bytes: &[u8], offset: &mut usize) -> Result<Geometry> {
     } else {
         None
     };
-    let kind = (raw_type & 0xffff) % 1000;
+    let kind = geometry_kind(raw_type);
     let body = match kind {
         1 => Body::Point(take_coordinate(bytes, offset, byte_order, dimensions)?),
         2 => Body::LineString(take_coordinates(bytes, offset, byte_order, dimensions)?),
@@ -508,8 +870,126 @@ mod tests {
         assert_eq!(rings.len(), 1);
         assert!(rings[0].len() >= 4);
         assert!(same_xy(&rings[0][0], rings[0].last().unwrap()));
-        assert_eq!(rings[0][0].0[..2], [0.0625, 0.0625]);
+        assert!(rings[0].iter().all(|coordinate| {
+            coordinate.0[..2]
+                .iter()
+                .all(|ordinate| *ordinate / 0.0625 == (*ordinate / 0.0625).round())
+        }));
         assert!(simplified.len() < wkb.len());
+    }
+
+    #[test]
+    fn polygon_simplification_does_not_introduce_self_intersection() {
+        // Plain RDP at tolerance 5 replaces the lower-left chain with a chord
+        // that crosses the closing edge from (2.12, -1.77) to (1.56, 0).
+        let coordinates = [
+            (1.56, 0.0),
+            (7.82, 4.37),
+            (2.37, 7.87),
+            (-1.29, 5.99),
+            (-2.58, 1.85),
+            (-2.26, 0.27),
+            (-1.11, -0.78),
+            (-1.22, -4.1),
+            (0.41, -1.45),
+            (2.12, -1.77),
+            (1.56, 0.0),
+        ];
+        let mut wkb = vec![1];
+        put_u32(&mut wkb, 3, 1);
+        put_u32(&mut wkb, 1, 1);
+        put_u32(&mut wkb, coordinates.len() as u32, 1);
+        for (x, y) in coordinates {
+            put_f64(&mut wkb, x, 1);
+            put_f64(&mut wkb, y, 1);
+        }
+
+        let simplified = simplify_wkb(&wkb, 5.0).unwrap();
+        let mut offset = 0;
+        let parsed = parse_geometry(&simplified, &mut offset).unwrap();
+        assert_valid_polygonal_geometry(&parsed);
+    }
+
+    #[test]
+    fn polygon_z_retries_without_inventing_z() {
+        let coordinates = [
+            (1.56, 0.0),
+            (7.82, 4.37),
+            (2.37, 7.87),
+            (-1.29, 5.99),
+            (-2.58, 1.85),
+            (-2.26, 0.27),
+            (-1.11, -0.78),
+            (-1.22, -4.1),
+            (0.41, -1.45),
+            (2.12, -1.77),
+            (1.56, 0.0),
+        ];
+        let mut wkb = vec![1];
+        put_u32(&mut wkb, 1003, 1); // ISO WKB Polygon Z
+        put_u32(&mut wkb, 1, 1);
+        put_u32(&mut wkb, coordinates.len() as u32, 1);
+        for (index, (x, y)) in coordinates.into_iter().enumerate() {
+            put_f64(&mut wkb, x, 1);
+            put_f64(&mut wkb, y, 1);
+            put_f64(&mut wkb, index as f64, 1);
+        }
+
+        let simplified = simplify_wkb(&wkb, 5.0).unwrap();
+        assert!(simplified.len() < wkb.len());
+        let mut offset = 0;
+        let parsed = parse_geometry(&simplified, &mut offset).unwrap();
+        assert_valid_polygonal_geometry(&parsed);
+        let Body::Polygon(rings) = parsed.body else {
+            panic!("expected polygon")
+        };
+        assert!(rings[0]
+            .iter()
+            .all(|coordinate| coordinate.0[2].fract() == 0.0));
+    }
+
+    #[test]
+    fn tiny_polygon_collapsed_by_quantization_is_revived_as_a_grid_cell() {
+        let coordinates = [
+            (0.0, 0.0),
+            (1.0, 0.49),
+            (2.0, 0.0),
+            (1.0, -0.49),
+            (0.0, 0.0),
+        ];
+        let mut wkb = vec![1];
+        put_u32(&mut wkb, 3, 1);
+        put_u32(&mut wkb, 1, 1);
+        put_u32(&mut wkb, coordinates.len() as u32, 1);
+        for (x, y) in coordinates {
+            put_f64(&mut wkb, x, 1);
+            put_f64(&mut wkb, y, 1);
+        }
+
+        let simplified = simplify_wkb(&wkb, 1.0).unwrap();
+        let mut offset = 0;
+        let parsed = parse_geometry(&simplified, &mut offset).unwrap();
+        assert_valid_polygonal_geometry(&parsed);
+        let Body::Polygon(rings) = parsed.body else {
+            panic!("expected polygon")
+        };
+        assert_eq!(rings[0].len(), 5);
+        assert_eq!(signed_area2(&rings[0]).abs() / 2.0, 1.0);
+        assert_ne!(simplified, wkb);
+        assert_eq!(first_viable_level(&wkb, &[1.0, 0.1]).unwrap(), 0);
+    }
+
+    fn assert_valid_polygonal_geometry(geometry: &Geometry) {
+        match (&geometry.body, geometry_kind(geometry.raw_type)) {
+            (Body::Polygon(rings), 3) => assert!(polygon_xy(rings).is_valid()),
+            (Body::Collection(children), 6) => {
+                assert!(!children.is_empty());
+                for child in children {
+                    assert_valid_polygonal_geometry(child);
+                }
+            }
+            _ => panic!("expected polygonal geometry"),
+        }
     }
 
     #[test]

--- a/cogp-rs/src/wkb_simplify.rs
+++ b/cogp-rs/src/wkb_simplify.rs
@@ -1,0 +1,520 @@
+//! Experimental scale-based WKB simplification for rendering overview columns.
+//!
+//! The simplifier preserves WKB byte order, type flags, SRID, and retained
+//! ordinates. Distance tests use XY only. Polygon rings keep their closure and
+//! minimum vertex count. A simplified line is viable only when its length
+//! exceeds the active tolerance. This local algorithm does not promise
+//! topology preservation across rings or neighboring features.
+
+use anyhow::{bail, Result};
+use byteorder::{BigEndian, ByteOrder, LittleEndian};
+
+#[derive(Clone)]
+struct Coordinate(Vec<f64>);
+
+#[derive(Clone)]
+struct Geometry {
+    byte_order: u8,
+    raw_type: u32,
+    srid: Option<u32>,
+    body: Body,
+}
+
+#[derive(Clone)]
+enum Body {
+    Point(Coordinate),
+    LineString(Vec<Coordinate>),
+    Polygon(Vec<Vec<Coordinate>>),
+    Collection(Vec<Geometry>),
+}
+
+pub fn simplify_wkb(bytes: &[u8], tolerance: f64) -> Result<Vec<u8>> {
+    if !tolerance.is_finite() || tolerance <= 0.0 {
+        bail!("simplification tolerance must be positive and finite");
+    }
+    let mut offset = 0;
+    let mut geometry = parse_geometry(bytes, &mut offset)?;
+    if offset != bytes.len() {
+        bail!("trailing bytes after WKB geometry");
+    }
+    // A source feature must remain available at the finest level. If even the
+    // requested tolerance cannot form a valid geometry, retaining raw WKB is
+    // a lossless (zero-error) fallback. Level assignment prevents this fallback
+    // at coarser levels by deferring the feature until simplification survives.
+    if !simplify_geometry(&mut geometry, tolerance * tolerance) {
+        return Ok(bytes.to_vec());
+    }
+    let mut output = Vec::with_capacity(bytes.len());
+    write_geometry(&geometry, &mut output);
+    Ok(output)
+}
+
+pub struct SimplificationProfile {
+    /// First coarse-to-fine tolerance at which the geometry remains valid.
+    pub minimum_viable_level: usize,
+    /// Exact encoded WKB length at every candidate tolerance. An invalid
+    /// candidate records the lossless fallback length.
+    pub wkb_sizes: Vec<u64>,
+}
+
+/// Evaluate one geometry across the complete candidate tolerance ladder.
+/// Parsing happens once; each candidate simplifies an independent clone so
+/// approximation error never accumulates between levels.
+pub fn simplification_profile(bytes: &[u8], tolerances: &[f64]) -> Result<SimplificationProfile> {
+    if tolerances.is_empty() {
+        bail!("simplification profile requires at least one tolerance");
+    }
+    let mut offset = 0;
+    let geometry = parse_geometry(bytes, &mut offset)?;
+    if offset != bytes.len() {
+        bail!("trailing bytes after WKB geometry");
+    }
+    let mut minimum_viable_level = None;
+    let mut wkb_sizes = Vec::with_capacity(tolerances.len());
+    for (level, tolerance) in tolerances.iter().enumerate() {
+        if !tolerance.is_finite() || *tolerance <= 0.0 {
+            bail!("simplification tolerance must be positive and finite");
+        }
+        let mut candidate = geometry.clone();
+        if simplify_geometry(&mut candidate, tolerance * tolerance) {
+            minimum_viable_level.get_or_insert(level);
+            wkb_sizes.push(geometry_wkb_size(&candidate));
+        } else {
+            wkb_sizes.push(bytes.len() as u64);
+        }
+    }
+    Ok(SimplificationProfile {
+        minimum_viable_level: minimum_viable_level.unwrap_or(tolerances.len() - 1),
+        wkb_sizes,
+    })
+}
+
+fn simplify_geometry(geometry: &mut Geometry, tolerance2: f64) -> bool {
+    match &mut geometry.body {
+        Body::Point(_) => true,
+        Body::LineString(points) => {
+            *points = simplify_line(points, tolerance2, 2);
+            points.len() >= 2 && line_length(points) > tolerance2.sqrt()
+        }
+        Body::Polygon(rings) => {
+            let Some(exterior) = rings
+                .first()
+                .and_then(|ring| simplify_ring(ring, tolerance2))
+            else {
+                return false;
+            };
+            let mut simplified = Vec::with_capacity(rings.len());
+            simplified.push(exterior);
+            // A collapsed interior ring is a sub-resolution hole, not a reason
+            // to discard an otherwise valid polygon.
+            for ring in &rings[1..] {
+                if let Some(ring) = simplify_ring(ring, tolerance2) {
+                    simplified.push(ring);
+                }
+            }
+            *rings = simplified;
+            true
+        }
+        Body::Collection(children) => {
+            children.retain_mut(|child| simplify_geometry(child, tolerance2));
+            !children.is_empty()
+        }
+    }
+}
+
+fn simplify_ring(ring: &[Coordinate], tolerance2: f64) -> Option<Vec<Coordinate>> {
+    if ring.len() < 4 || !same_xy(&ring[0], ring.last()?) {
+        return None;
+    }
+    let mut simplified = simplify_line(&ring[..ring.len() - 1], tolerance2, 2);
+    if simplified.len() < 3 || signed_area2(&simplified) == 0.0 {
+        return None;
+    }
+    simplified.push(simplified[0].clone());
+    Some(simplified)
+}
+
+fn signed_area2(points: &[Coordinate]) -> f64 {
+    let mut area2 = 0.0;
+    for index in 0..points.len() {
+        let next = (index + 1) % points.len();
+        area2 += points[index].0[0] * points[next].0[1] - points[next].0[0] * points[index].0[1];
+    }
+    area2
+}
+
+fn line_length(points: &[Coordinate]) -> f64 {
+    points
+        .windows(2)
+        .map(|segment| {
+            let dx = segment[1].0[0] - segment[0].0[0];
+            let dy = segment[1].0[1] - segment[0].0[1];
+            dx.hypot(dy)
+        })
+        .sum()
+}
+
+fn geometry_wkb_size(geometry: &Geometry) -> u64 {
+    let header = 1 + 4 + u64::from(geometry.srid.is_some()) * 4;
+    header
+        + match &geometry.body {
+            Body::Point(point) => coordinate_bytes(point),
+            Body::LineString(points) => 4 + coordinates_bytes(points),
+            Body::Polygon(rings) => {
+                4 + rings
+                    .iter()
+                    .map(|ring| 4 + coordinates_bytes(ring))
+                    .sum::<u64>()
+            }
+            Body::Collection(children) => 4 + children.iter().map(geometry_wkb_size).sum::<u64>(),
+        }
+}
+
+fn coordinate_bytes(coordinate: &Coordinate) -> u64 {
+    coordinate.0.len() as u64 * 8
+}
+
+fn coordinates_bytes(coordinates: &[Coordinate]) -> u64 {
+    coordinates.iter().map(coordinate_bytes).sum()
+}
+
+/// Ramer-Douglas-Peucker with a minimum output cardinality. Every overview is
+/// derived directly from raw WKB, so errors do not accumulate between levels.
+fn simplify_line(points: &[Coordinate], tolerance2: f64, minimum: usize) -> Vec<Coordinate> {
+    if points.len() <= minimum {
+        return points.to_vec();
+    }
+    let mut keep = vec![false; points.len()];
+    keep[0] = true;
+    keep[points.len() - 1] = true;
+    let mut stack = vec![(0usize, points.len() - 1)];
+    while let Some((start, end)) = stack.pop() {
+        let mut greatest_distance2 = tolerance2;
+        let mut greatest_index = None;
+        for index in start + 1..end {
+            let distance2 = segment_distance2(&points[index], &points[start], &points[end]);
+            if distance2 > greatest_distance2 {
+                greatest_distance2 = distance2;
+                greatest_index = Some(index);
+            }
+        }
+        if let Some(index) = greatest_index {
+            keep[index] = true;
+            stack.push((start, index));
+            stack.push((index, end));
+        }
+    }
+    let simplified: Vec<Coordinate> = points
+        .iter()
+        .zip(keep)
+        .filter(|(_, keep)| *keep)
+        .map(|(point, _)| point.clone())
+        .collect();
+    if simplified.len() < minimum {
+        points.to_vec()
+    } else {
+        simplified
+    }
+}
+
+fn segment_distance2(point: &Coordinate, start: &Coordinate, end: &Coordinate) -> f64 {
+    let (px, py) = (point.0[0], point.0[1]);
+    let (ax, ay) = (start.0[0], start.0[1]);
+    let (bx, by) = (end.0[0], end.0[1]);
+    let (dx, dy) = (bx - ax, by - ay);
+    if dx == 0.0 && dy == 0.0 {
+        return (px - ax).powi(2) + (py - ay).powi(2);
+    }
+    let t = (((px - ax) * dx + (py - ay) * dy) / (dx * dx + dy * dy)).clamp(0.0, 1.0);
+    (px - (ax + t * dx)).powi(2) + (py - (ay + t * dy)).powi(2)
+}
+
+fn same_xy(left: &Coordinate, right: &Coordinate) -> bool {
+    left.0[0] == right.0[0] && left.0[1] == right.0[1]
+}
+
+fn parse_geometry(bytes: &[u8], offset: &mut usize) -> Result<Geometry> {
+    let byte_order = take_u8(bytes, offset)?;
+    if byte_order > 1 {
+        bail!("invalid WKB byte order: {byte_order}");
+    }
+    let raw_type = take_u32(bytes, offset, byte_order)?;
+    let has_z = raw_type & 0x8000_0000 != 0 || matches!((raw_type / 1000) % 10, 1 | 3);
+    let has_m = raw_type & 0x4000_0000 != 0 || matches!((raw_type / 1000) % 10, 2 | 3);
+    let dimensions = 2 + usize::from(has_z) + usize::from(has_m);
+    let srid = if raw_type & 0x2000_0000 != 0 {
+        Some(take_u32(bytes, offset, byte_order)?)
+    } else {
+        None
+    };
+    let kind = (raw_type & 0xffff) % 1000;
+    let body = match kind {
+        1 => Body::Point(take_coordinate(bytes, offset, byte_order, dimensions)?),
+        2 => Body::LineString(take_coordinates(bytes, offset, byte_order, dimensions)?),
+        3 => {
+            let count = take_u32(bytes, offset, byte_order)? as usize;
+            let mut rings = Vec::with_capacity(count);
+            for _ in 0..count {
+                rings.push(take_coordinates(bytes, offset, byte_order, dimensions)?);
+            }
+            Body::Polygon(rings)
+        }
+        4..=7 => {
+            let count = take_u32(bytes, offset, byte_order)? as usize;
+            let mut children = Vec::with_capacity(count);
+            for _ in 0..count {
+                children.push(parse_geometry(bytes, offset)?);
+            }
+            Body::Collection(children)
+        }
+        _ => bail!("unsupported WKB geometry type: {kind}"),
+    };
+    Ok(Geometry {
+        byte_order,
+        raw_type,
+        srid,
+        body,
+    })
+}
+
+fn write_geometry(geometry: &Geometry, output: &mut Vec<u8>) {
+    output.push(geometry.byte_order);
+    put_u32(output, geometry.raw_type, geometry.byte_order);
+    if let Some(srid) = geometry.srid {
+        put_u32(output, srid, geometry.byte_order);
+    }
+    match &geometry.body {
+        Body::Point(point) => put_coordinate(output, point, geometry.byte_order),
+        Body::LineString(points) => put_coordinates(output, points, geometry.byte_order),
+        Body::Polygon(rings) => {
+            put_u32(output, rings.len() as u32, geometry.byte_order);
+            for ring in rings {
+                put_coordinates(output, ring, geometry.byte_order);
+            }
+        }
+        Body::Collection(children) => {
+            put_u32(output, children.len() as u32, geometry.byte_order);
+            for child in children {
+                write_geometry(child, output);
+            }
+        }
+    }
+}
+
+fn take_u8(bytes: &[u8], offset: &mut usize) -> Result<u8> {
+    let value = *bytes
+        .get(*offset)
+        .ok_or_else(|| anyhow::anyhow!("truncated WKB"))?;
+    *offset += 1;
+    Ok(value)
+}
+
+fn take_u32(bytes: &[u8], offset: &mut usize, order: u8) -> Result<u32> {
+    let bytes = take(bytes, offset, 4)?;
+    Ok(if order == 0 {
+        BigEndian::read_u32(bytes)
+    } else {
+        LittleEndian::read_u32(bytes)
+    })
+}
+
+fn take_f64(bytes: &[u8], offset: &mut usize, order: u8) -> Result<f64> {
+    let bytes = take(bytes, offset, 8)?;
+    Ok(if order == 0 {
+        BigEndian::read_f64(bytes)
+    } else {
+        LittleEndian::read_f64(bytes)
+    })
+}
+
+fn take<'a>(bytes: &'a [u8], offset: &mut usize, length: usize) -> Result<&'a [u8]> {
+    let end = offset
+        .checked_add(length)
+        .ok_or_else(|| anyhow::anyhow!("WKB offset overflow"))?;
+    let value = bytes
+        .get(*offset..end)
+        .ok_or_else(|| anyhow::anyhow!("truncated WKB"))?;
+    *offset = end;
+    Ok(value)
+}
+
+fn take_coordinate(
+    bytes: &[u8],
+    offset: &mut usize,
+    order: u8,
+    dimensions: usize,
+) -> Result<Coordinate> {
+    let mut ordinates = Vec::with_capacity(dimensions);
+    for _ in 0..dimensions {
+        ordinates.push(take_f64(bytes, offset, order)?);
+    }
+    Ok(Coordinate(ordinates))
+}
+
+fn take_coordinates(
+    bytes: &[u8],
+    offset: &mut usize,
+    order: u8,
+    dimensions: usize,
+) -> Result<Vec<Coordinate>> {
+    let count = take_u32(bytes, offset, order)? as usize;
+    let mut coordinates = Vec::with_capacity(count);
+    for _ in 0..count {
+        coordinates.push(take_coordinate(bytes, offset, order, dimensions)?);
+    }
+    Ok(coordinates)
+}
+
+fn put_u32(output: &mut Vec<u8>, value: u32, order: u8) {
+    let mut bytes = [0; 4];
+    if order == 0 {
+        BigEndian::write_u32(&mut bytes, value);
+    } else {
+        LittleEndian::write_u32(&mut bytes, value);
+    }
+    output.extend_from_slice(&bytes);
+}
+
+fn put_f64(output: &mut Vec<u8>, value: f64, order: u8) {
+    let mut bytes = [0; 8];
+    if order == 0 {
+        BigEndian::write_f64(&mut bytes, value);
+    } else {
+        LittleEndian::write_f64(&mut bytes, value);
+    }
+    output.extend_from_slice(&bytes);
+}
+
+fn put_coordinate(output: &mut Vec<u8>, coordinate: &Coordinate, order: u8) {
+    for ordinate in &coordinate.0 {
+        put_f64(output, *ordinate, order);
+    }
+}
+
+fn put_coordinates(output: &mut Vec<u8>, coordinates: &[Coordinate], order: u8) {
+    put_u32(output, coordinates.len() as u32, order);
+    for coordinate in coordinates {
+        put_coordinate(output, coordinate, order);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn simplifies_a_linestring_from_raw_tolerance() {
+        let mut wkb = vec![1];
+        put_u32(&mut wkb, 2, 1);
+        put_u32(&mut wkb, 4, 1);
+        for (x, y) in [(0., 0.), (1., 0.01), (2., -0.01), (3., 0.)] {
+            put_f64(&mut wkb, x, 1);
+            put_f64(&mut wkb, y, 1);
+        }
+        let simplified = simplify_wkb(&wkb, 0.1).unwrap();
+        assert!(simplified.len() < wkb.len());
+        let mut offset = 0;
+        let parsed = parse_geometry(&simplified, &mut offset).unwrap();
+        let Body::LineString(points) = parsed.body else {
+            panic!("expected linestring")
+        };
+        assert_eq!(points.len(), 2);
+        assert_eq!(points[0].0[..2], [0., 0.]);
+        assert_eq!(points[1].0[..2], [3., 0.]);
+    }
+
+    #[test]
+    fn line_viability_defers_sub_tolerance_results() {
+        let mut wkb = vec![1];
+        put_u32(&mut wkb, 2, 1);
+        put_u32(&mut wkb, 2, 1);
+        for (x, y) in [(0., 0.), (0.25, 0.)] {
+            put_f64(&mut wkb, x, 1);
+            put_f64(&mut wkb, y, 1);
+        }
+
+        let profile = simplification_profile(&wkb, &[1.0, 0.1]).unwrap();
+        assert_eq!(profile.minimum_viable_level, 1);
+        assert_eq!(profile.wkb_sizes[0], wkb.len() as u64);
+        assert_eq!(profile.wkb_sizes[1], wkb.len() as u64);
+    }
+
+    #[test]
+    fn polygon_ring_remains_closed_and_has_minimum_vertices() {
+        let coordinates = [(0., 0.), (0.5, 0.), (1., 0.), (1., 1.), (0., 1.), (0., 0.)];
+        let mut wkb = vec![1];
+        put_u32(&mut wkb, 3, 1);
+        put_u32(&mut wkb, 1, 1);
+        put_u32(&mut wkb, coordinates.len() as u32, 1);
+        for (x, y) in coordinates {
+            put_f64(&mut wkb, x, 1);
+            put_f64(&mut wkb, y, 1);
+        }
+
+        let simplified = simplify_wkb(&wkb, 0.1).unwrap();
+        let mut offset = 0;
+        let parsed = parse_geometry(&simplified, &mut offset).unwrap();
+        let Body::Polygon(rings) = parsed.body else {
+            panic!("expected polygon")
+        };
+        assert_eq!(rings.len(), 1);
+        assert!(rings[0].len() >= 4);
+        assert!(same_xy(&rings[0][0], rings[0].last().unwrap()));
+        assert!(simplified.len() < wkb.len());
+    }
+
+    #[test]
+    fn coarse_polygon_tolerance_falls_back_to_raw_at_the_final_level() {
+        let mut coordinates = Vec::new();
+        for x in 0..=100 {
+            coordinates.push((x as f64 / 100.0, 0.0));
+        }
+        for y in 1..=100 {
+            coordinates.push((1.0, y as f64 / 100.0));
+        }
+        for x in (0..100).rev() {
+            coordinates.push((x as f64 / 100.0, 1.0));
+        }
+        for y in (1..100).rev() {
+            coordinates.push((0.0, y as f64 / 100.0));
+        }
+        coordinates.push(coordinates[0]);
+
+        let mut wkb = vec![1];
+        put_u32(&mut wkb, 3, 1);
+        put_u32(&mut wkb, 1, 1);
+        put_u32(&mut wkb, coordinates.len() as u32, 1);
+        for (x, y) in coordinates {
+            put_f64(&mut wkb, x, 1);
+            put_f64(&mut wkb, y, 1);
+        }
+
+        let simplified = simplify_wkb(&wkb, 10.0).unwrap();
+        let mut offset = 0;
+        let parsed = parse_geometry(&simplified, &mut offset).unwrap();
+        let Body::Polygon(rings) = parsed.body else {
+            panic!("expected polygon")
+        };
+        assert_eq!(rings[0].len(), 401);
+        assert!(same_xy(&rings[0][0], rings[0].last().unwrap()));
+        assert_eq!(simplified, wkb);
+    }
+
+    #[test]
+    fn polygon_viability_defers_until_a_ring_survives() {
+        let coordinates = [(0., 0.), (1., 0.), (1., 1.), (0., 1.), (0., 0.)];
+        let mut wkb = vec![1];
+        put_u32(&mut wkb, 3, 1);
+        put_u32(&mut wkb, 1, 1);
+        put_u32(&mut wkb, coordinates.len() as u32, 1);
+        for (x, y) in coordinates {
+            put_f64(&mut wkb, x, 1);
+            put_f64(&mut wkb, y, 1);
+        }
+
+        let profile = simplification_profile(&wkb, &[10.0, 0.1]).unwrap();
+        assert_eq!(profile.minimum_viable_level, 1);
+        assert_eq!(profile.wkb_sizes.len(), 2);
+        assert!(profile.wkb_sizes[1] <= wkb.len() as u64);
+    }
+}

--- a/cogp-rs/src/wkb_simplify.rs
+++ b/cogp-rs/src/wkb_simplify.rs
@@ -1,10 +1,12 @@
 //! Experimental scale-based WKB simplification for rendering overview columns.
 //!
 //! The simplifier preserves WKB byte order, type flags, SRID, and retained
-//! ordinates. Distance tests use XY only. Polygon rings keep their closure and
-//! minimum vertex count. A simplified line is viable only when its length
-//! exceeds the active tolerance. This local algorithm does not promise
-//! topology preservation across rings or neighboring features.
+//! ordinates. Distance tests use XY only. Retained XY coordinates are snapped
+//! to a power-of-two grid no coarser than the tolerance so their f64 low bits
+//! compress well; Z/M ordinates remain lossless. Polygon rings keep their closure and minimum
+//! vertex count. A simplified line is viable only when its length exceeds the
+//! active tolerance. This local algorithm does not promise topology
+//! preservation across rings or neighboring features.
 
 use anyhow::{bail, Result};
 use byteorder::{BigEndian, ByteOrder, LittleEndian};
@@ -44,23 +46,16 @@ pub fn simplify_wkb(bytes: &[u8], tolerance: f64) -> Result<Vec<u8>> {
     if !simplify_geometry(&mut geometry, tolerance * tolerance) {
         return Ok(bytes.to_vec());
     }
+    quantize_geometry(&mut geometry, quantization_grid(tolerance));
     let mut output = Vec::with_capacity(bytes.len());
     write_geometry(&geometry, &mut output);
     Ok(output)
 }
 
-pub struct SimplificationProfile {
-    /// First coarse-to-fine tolerance at which the geometry remains valid.
-    pub minimum_viable_level: usize,
-    /// Exact encoded WKB length at every candidate tolerance. An invalid
-    /// candidate records the lossless fallback length.
-    pub wkb_sizes: Vec<u64>,
-}
-
-/// Evaluate one geometry across the complete candidate tolerance ladder.
-/// Parsing happens once; each candidate simplifies an independent clone so
-/// approximation error never accumulates between levels.
-pub fn simplification_profile(bytes: &[u8], tolerances: &[f64]) -> Result<SimplificationProfile> {
+/// Return the first coarse-to-fine tolerance at which the geometry remains
+/// independently renderable. Parsing happens once; each candidate simplifies
+/// an independent clone so approximation error never accumulates between levels.
+pub fn first_viable_level(bytes: &[u8], tolerances: &[f64]) -> Result<usize> {
     if tolerances.is_empty() {
         bail!("simplification profile requires at least one tolerance");
     }
@@ -69,24 +64,64 @@ pub fn simplification_profile(bytes: &[u8], tolerances: &[f64]) -> Result<Simpli
     if offset != bytes.len() {
         bail!("trailing bytes after WKB geometry");
     }
-    let mut minimum_viable_level = None;
-    let mut wkb_sizes = Vec::with_capacity(tolerances.len());
     for (level, tolerance) in tolerances.iter().enumerate() {
         if !tolerance.is_finite() || *tolerance <= 0.0 {
             bail!("simplification tolerance must be positive and finite");
         }
         let mut candidate = geometry.clone();
         if simplify_geometry(&mut candidate, tolerance * tolerance) {
-            minimum_viable_level.get_or_insert(level);
-            wkb_sizes.push(geometry_wkb_size(&candidate));
-        } else {
-            wkb_sizes.push(bytes.len() as u64);
+            return Ok(level);
         }
     }
-    Ok(SimplificationProfile {
-        minimum_viable_level: minimum_viable_level.unwrap_or(tolerances.len() - 1),
-        wkb_sizes,
-    })
+    Ok(tolerances.len() - 1)
+}
+
+/// Choose the largest power-of-two grid spacing no greater than the requested
+/// tolerance. Besides staying inside the existing precision budget, this makes
+/// rounded f64 values share zeroed mantissa bits instead of merely sharing
+/// multiples of an arbitrary floating-point value.
+fn quantization_grid(tolerance: f64) -> f64 {
+    let grid = f64::from_bits(tolerance.to_bits() & 0x7ff0_0000_0000_0000);
+    if grid == 0.0 {
+        tolerance
+    } else {
+        grid
+    }
+}
+
+/// Snap rendering-only XY coordinates without changing vertex counts or ring
+/// closure. Keeping the representation as f64 preserves GeoParquet/WKB
+/// compatibility while giving ZSTD highly repetitive low-order bytes.
+fn quantize_geometry(geometry: &mut Geometry, grid: f64) {
+    match &mut geometry.body {
+        Body::Point(point) => quantize_coordinate(point, grid),
+        Body::LineString(points) => quantize_coordinates(points, grid),
+        Body::Polygon(rings) => {
+            for ring in rings {
+                quantize_coordinates(ring, grid);
+            }
+        }
+        Body::Collection(children) => {
+            for child in children {
+                quantize_geometry(child, grid);
+            }
+        }
+    }
+}
+
+fn quantize_coordinates(points: &mut [Coordinate], grid: f64) {
+    for point in points {
+        quantize_coordinate(point, grid);
+    }
+}
+
+fn quantize_coordinate(coordinate: &mut Coordinate, grid: f64) {
+    for ordinate in &mut coordinate.0[..2] {
+        let snapped = (*ordinate / grid).round() * grid;
+        // Canonicalize negative zero as well as the coordinate value. This is
+        // invisible geometrically but avoids two byte patterns for grid zero.
+        *ordinate = if snapped == 0.0 { 0.0 } else { snapped };
+    }
 }
 
 fn simplify_geometry(geometry: &mut Geometry, tolerance2: f64) -> bool {
@@ -152,30 +187,6 @@ fn line_length(points: &[Coordinate]) -> f64 {
             dx.hypot(dy)
         })
         .sum()
-}
-
-fn geometry_wkb_size(geometry: &Geometry) -> u64 {
-    let header = 1 + 4 + u64::from(geometry.srid.is_some()) * 4;
-    header
-        + match &geometry.body {
-            Body::Point(point) => coordinate_bytes(point),
-            Body::LineString(points) => 4 + coordinates_bytes(points),
-            Body::Polygon(rings) => {
-                4 + rings
-                    .iter()
-                    .map(|ring| 4 + coordinates_bytes(ring))
-                    .sum::<u64>()
-            }
-            Body::Collection(children) => 4 + children.iter().map(geometry_wkb_size).sum::<u64>(),
-        }
-}
-
-fn coordinate_bytes(coordinate: &Coordinate) -> u64 {
-    coordinate.0.len() as u64 * 8
-}
-
-fn coordinates_bytes(coordinates: &[Coordinate]) -> u64 {
-    coordinates.iter().map(coordinate_bytes).sum()
 }
 
 /// Ramer-Douglas-Peucker with a minimum output cardinality. Every overview is
@@ -424,6 +435,39 @@ mod tests {
     }
 
     #[test]
+    fn simplified_xy_is_snapped_but_z_is_preserved() {
+        let mut wkb = vec![1];
+        put_u32(&mut wkb, 1002, 1); // ISO WKB LineString Z
+        put_u32(&mut wkb, 3, 1);
+        for (x, y, z) in [
+            (0.04, 0.04, 12.345),
+            (1.5, 0.01, 23.456),
+            (2.96, -0.04, 34.567),
+        ] {
+            put_f64(&mut wkb, x, 1);
+            put_f64(&mut wkb, y, 1);
+            put_f64(&mut wkb, z, 1);
+        }
+
+        let simplified = simplify_wkb(&wkb, 0.1).unwrap();
+        let mut offset = 0;
+        let parsed = parse_geometry(&simplified, &mut offset).unwrap();
+        let Body::LineString(points) = parsed.body else {
+            panic!("expected linestring")
+        };
+        assert_eq!(points.len(), 2);
+        assert_eq!(points[0].0, [0.0625, 0.0625, 12.345]);
+        assert_eq!(points[1].0, [2.9375, -0.0625, 34.567]);
+    }
+
+    #[test]
+    fn quantization_grid_is_binary_and_no_coarser_than_tolerance() {
+        assert_eq!(quantization_grid(0.1), 0.0625);
+        assert_eq!(quantization_grid(1024.0), 1024.0);
+        assert!(quantization_grid(1000.0) <= 1000.0);
+    }
+
+    #[test]
     fn line_viability_defers_sub_tolerance_results() {
         let mut wkb = vec![1];
         put_u32(&mut wkb, 2, 1);
@@ -433,15 +477,19 @@ mod tests {
             put_f64(&mut wkb, y, 1);
         }
 
-        let profile = simplification_profile(&wkb, &[1.0, 0.1]).unwrap();
-        assert_eq!(profile.minimum_viable_level, 1);
-        assert_eq!(profile.wkb_sizes[0], wkb.len() as u64);
-        assert_eq!(profile.wkb_sizes[1], wkb.len() as u64);
+        assert_eq!(first_viable_level(&wkb, &[1.0, 0.1]).unwrap(), 1);
     }
 
     #[test]
     fn polygon_ring_remains_closed_and_has_minimum_vertices() {
-        let coordinates = [(0., 0.), (0.5, 0.), (1., 0.), (1., 1.), (0., 1.), (0., 0.)];
+        let coordinates = [
+            (0.04, 0.04),
+            (0.54, 0.04),
+            (1.04, 0.04),
+            (1.04, 1.04),
+            (0.04, 1.04),
+            (0.04, 0.04),
+        ];
         let mut wkb = vec![1];
         put_u32(&mut wkb, 3, 1);
         put_u32(&mut wkb, 1, 1);
@@ -460,6 +508,7 @@ mod tests {
         assert_eq!(rings.len(), 1);
         assert!(rings[0].len() >= 4);
         assert!(same_xy(&rings[0][0], rings[0].last().unwrap()));
+        assert_eq!(rings[0][0].0[..2], [0.0625, 0.0625]);
         assert!(simplified.len() < wkb.len());
     }
 
@@ -512,9 +561,6 @@ mod tests {
             put_f64(&mut wkb, y, 1);
         }
 
-        let profile = simplification_profile(&wkb, &[10.0, 0.1]).unwrap();
-        assert_eq!(profile.minimum_viable_level, 1);
-        assert_eq!(profile.wkb_sizes.len(), 2);
-        assert!(profile.wkb_sizes[1] <= wkb.len() as u64);
+        assert_eq!(first_viable_level(&wkb, &[10.0, 0.1]).unwrap(), 1);
     }
 }

--- a/cogp-rs/tests/end_to_end.rs
+++ b/cogp-rs/tests/end_to_end.rs
@@ -191,7 +191,7 @@ fn convert_args(input: &std::path::Path, output: &std::path::Path) -> ConvertArg
     ConvertArgs {
         input: input.to_path_buf(),
         output: output.to_path_buf(),
-        gsd: vec![],
+        resolution: vec![],
         webmerc_minzoom: 0,
         webmerc_maxzoom: 4,
         row_group_size: 8,
@@ -223,41 +223,39 @@ fn convert_reader_validate_pipeline() {
     assert_eq!(reader.primary_column(), "geometry");
 
     let cogp = reader.cogp_meta();
-    assert!(!cogp.geometry_overviews.is_empty());
-    assert_eq!(cogp.geometry_overviews.len(), cogp.levels.len());
     assert!(cogp
-        .geometry_overviews
+        .levels
         .iter()
-        .enumerate()
-        .all(|(level, overview)| overview.level == level));
-    let coarsest_overview = &cogp.geometry_overviews[0];
+        .all(|level| level.geometry_column.starts_with("geometry_ovr_")));
     assert_eq!(
-        reader.geometry_column_for_gsd(cogp.levels[coarsest_overview.level].gsd),
-        coarsest_overview.column
+        reader.geometry_column_for_resolution(cogp.levels[0].resolution_meters),
+        cogp.levels[0].geometry_column
     );
-    let finest_overview = cogp.geometry_overviews.last().unwrap();
-    assert_eq!(finest_overview.level, cogp.levels.len() - 1);
+    let finest_level = cogp.levels.last().unwrap();
     assert_eq!(
-        reader.geometry_column_for_gsd(cogp.levels[finest_overview.level].gsd / 2.0),
-        finest_overview.column
+        reader.geometry_column_for_resolution(finest_level.resolution_meters / 2.0),
+        finest_level.geometry_column
     );
     // levels list constraints (validator already checks these but assert here
     // so the reader's view stays in sync).
     let mut prev_rge: Option<i64> = None;
-    let mut prev_gsd: Option<f64> = None;
+    let mut previous_resolution: Option<f64> = None;
     for l in &cogp.levels {
         if let Some(p) = prev_rge {
             assert!(l.row_group_end > p);
         }
         prev_rge = Some(l.row_group_end);
-        assert!(l.gsd > 0.0);
-        if let Some(p) = prev_gsd {
-            assert!(l.gsd < p);
+        assert!(l.resolution_meters > 0.0);
+        if let Some(previous) = previous_resolution {
+            assert!(l.resolution_meters < previous);
         }
-        prev_gsd = Some(l.gsd);
+        previous_resolution = Some(l.resolution_meters);
     }
     let total_rgs = reader.num_row_groups();
-    assert_eq!(cogp.levels.last().unwrap().row_group_end as usize + 1, total_rgs);
+    assert_eq!(
+        cogp.levels.last().unwrap().row_group_end as usize + 1,
+        total_rgs
+    );
 
     // The profile relies only on row-group statistics; the converter must not
     // add page-level index structures to the output.
@@ -280,16 +278,15 @@ fn convert_reader_validate_pipeline() {
     let up_to_huge = reader.row_groups_up_to_level(999);
     assert_eq!(up_to_huge.end, total_rgs);
 
-    // `row_groups_up_to_gsd` returns levels whose GSD is ≥ min_gsd (i.e.
-    // coarser than the caller's target). Tiny min_gsd → every level
-    // qualifies; huge min_gsd → no level is that coarse.
-    let everything = reader.row_groups_up_to_gsd(1e-12);
-    let nothing = reader.row_groups_up_to_gsd(1e12);
+    // Tiny target resolution includes every level; a huge target has no level
+    // coarse enough to qualify.
+    let everything = reader.row_groups_up_to_resolution(1e-12);
+    let nothing = reader.row_groups_up_to_resolution(1e12);
     assert_eq!(everything.end, total_rgs);
     assert!(nothing.is_empty());
-    // The coarsest level's own GSD must qualify itself.
-    let coarsest_gsd = reader.levels()[0].gsd;
-    let with_coarsest = reader.row_groups_up_to_gsd(coarsest_gsd);
+    // The coarsest level's own resolution must qualify itself.
+    let coarsest_resolution = reader.levels()[0].resolution_meters;
+    let with_coarsest = reader.row_groups_up_to_resolution(coarsest_resolution);
     assert!(!with_coarsest.is_empty());
 
     // The dataset spans roughly [0,0]..[10,4] in degrees; an outside query
@@ -309,16 +306,54 @@ fn convert_reader_validate_pipeline() {
         .collect();
     let total_rows: usize = batches.iter().map(|b| b.num_rows()).sum();
     assert_eq!(total_rows, 40, "all input rows must survive convert");
+    // Overview quantization must never leak into the lossless primary column.
+    for batch in &batches {
+        let ids = batch
+            .column_by_name("id")
+            .unwrap()
+            .as_any()
+            .downcast_ref::<Int32Array>()
+            .unwrap();
+        let geometry = batch
+            .column_by_name("geometry")
+            .unwrap()
+            .as_any()
+            .downcast_ref::<BinaryArray>()
+            .unwrap();
+        for row in 0..batch.num_rows() {
+            let id = ids.value(row);
+            let x0 = f64::from(id % 10);
+            let y0 = f64::from(id / 10);
+            let size = if id % 3 == 0 { 0.05 } else { 0.5 };
+            let expected = wkb::polygon(&[
+                (x0, y0),
+                (x0 + size, y0),
+                (x0 + size, y0 + size),
+                (x0, y0 + size),
+                (x0, y0),
+            ]);
+            assert_eq!(geometry.value(row), expected);
+        }
+    }
 
     // Bbox struct must be present in the output schema and be a non-nullable
     // struct of four f64 children.
     let schema = batches[0].schema();
     let bbox_field = schema.field_with_name("bbox").unwrap();
-    for overview in &cogp.geometry_overviews {
-        let field = schema.field_with_name(&overview.column).unwrap();
+    let mut geometry_boundaries = BTreeMap::new();
+    for level in &cogp.levels {
+        geometry_boundaries
+            .entry(level.geometry_column.as_str())
+            .and_modify(|boundary: &mut usize| {
+                *boundary = (*boundary).max(level.row_group_end as usize)
+            })
+            .or_insert(level.row_group_end as usize);
+    }
+    for column in geometry_boundaries.keys() {
+        let field = schema.field_with_name(column).unwrap();
         assert_eq!(field.data_type(), &DataType::Binary);
-        assert!(field.is_nullable());
-        assert!(reader.geo_meta().columns.contains_key(&overview.column));
+        assert!(field.is_nullable() || *column == reader.primary_column());
+        assert!(reader.geo_meta().columns.contains_key(*column));
     }
     match bbox_field.data_type() {
         DataType::Struct(fs) => {
@@ -331,8 +366,8 @@ fn convert_reader_validate_pipeline() {
         other => panic!("bbox must be a struct, got {other:?}"),
     }
 
-    // Each overview is complete through its linked feature-level boundary and
-    // entirely NULL afterward. This lets a renderer read one projected WKB
+    // Each level geometry is complete through its greatest referenced boundary
+    // and entirely NULL afterward. This lets a renderer read one projected WKB
     // column without per-row fallback.
     for row_group_index in 0..total_rgs {
         let file = File::open(&output).unwrap();
@@ -341,17 +376,22 @@ fn convert_reader_validate_pipeline() {
             .unwrap()
             .map(|batch| batch.unwrap())
             .collect();
-        for overview in &cogp.geometry_overviews {
-            let boundary = cogp.levels[overview.level].row_group_end as usize;
-            let (nulls, rows) = row_group_batches.iter().fold((0, 0), |(nulls, rows), batch| {
-                let column = batch.column_by_name(&overview.column).unwrap();
-                (nulls + column.null_count(), rows + batch.num_rows())
-            });
+        for (column_name, boundary) in &geometry_boundaries {
+            let (nulls, rows) = row_group_batches
+                .iter()
+                .fold((0, 0), |(nulls, rows), batch| {
+                    let column = batch.column_by_name(column_name).unwrap();
+                    (nulls + column.null_count(), rows + batch.num_rows())
+                });
             assert_eq!(
                 nulls,
-                if row_group_index <= boundary { 0 } else { rows },
+                if row_group_index <= *boundary {
+                    0
+                } else {
+                    rows
+                },
                 "unexpected sparse layout for {} in row group {row_group_index}",
-                overview.column
+                column_name
             );
         }
     }
@@ -365,16 +405,22 @@ fn convert_point_uses_primary_wkb_without_overviews() {
     write_point_input(&input);
 
     let mut args = convert_args(&input, &output);
-    args.gsd = vec![100_000.0, 10_000.0, 1_000.0];
+    args.resolution = vec![100_000.0, 10_000.0, 1_000.0];
     args.row_group_size = 8;
     args.row_group_max_bytes = Some(42);
     cogp::convert::run(args).unwrap();
     cogp::validate::run(&output).unwrap();
 
     let reader = Reader::open(&output).unwrap();
-    assert!(reader.geometry_overviews().is_empty());
-    assert_eq!(reader.geometry_column_for_gsd(1.0), "geometry");
-    assert!(reader.num_row_groups() > 1, "primary WKB must drive the byte budget");
+    assert!(reader
+        .levels()
+        .iter()
+        .all(|level| level.geometry_column == "geometry"));
+    assert_eq!(reader.geometry_column_for_resolution(1.0), "geometry");
+    assert!(
+        reader.num_row_groups() > 1,
+        "primary WKB must drive the byte budget"
+    );
 
     let all_row_groups: Vec<usize> = (0..reader.num_row_groups()).collect();
     let batches: Vec<RecordBatch> = reader
@@ -384,18 +430,21 @@ fn convert_point_uses_primary_wkb_without_overviews() {
         .collect();
     let schema = batches[0].schema();
     assert!(schema.field_with_name("geometry").is_ok());
-    assert!(schema.fields().iter().all(|field| !field.name().starts_with("geometry_ovr_")));
+    assert!(schema
+        .fields()
+        .iter()
+        .all(|field| !field.name().starts_with("geometry_ovr_")));
     assert_eq!(batches.iter().map(RecordBatch::num_rows).sum::<usize>(), 8);
 }
 
 #[test]
-fn convert_rejects_non_positive_gsd() {
-    let tmp = TempDir::new("badgsd");
+fn convert_rejects_non_positive_resolution() {
+    let tmp = TempDir::new("bad-resolution");
     let input = tmp.path().join("input.parquet");
     let output = tmp.path().join("out.parquet");
     write_input(&input);
     let mut args = convert_args(&input, &output);
-    args.gsd = vec![100.0, -1.0];
+    args.resolution = vec![100.0, -1.0];
     let err = cogp::convert::run(args).unwrap_err();
     let msg = format!("{err}");
     assert!(
@@ -433,11 +482,7 @@ fn convert_reuses_existing_bbox_column() {
     ]);
     let schema = Arc::new(Schema::new(vec![
         Field::new("id", DataType::Int32, false),
-        Field::new(
-            "bbox",
-            DataType::Struct(bbox_struct_fields.clone()),
-            false,
-        ),
+        Field::new("bbox", DataType::Struct(bbox_struct_fields.clone()), false),
         Field::new("geometry", DataType::Binary, false),
     ]));
 
@@ -482,8 +527,7 @@ fn convert_reuses_existing_bbox_column() {
     let geom_arr: ArrayRef = Arc::new(BinaryArray::from(
         geoms.iter().map(|v| v.as_slice()).collect::<Vec<_>>(),
     ));
-    let batch =
-        RecordBatch::try_new(schema.clone(), vec![id_arr, bbox_arr, geom_arr]).unwrap();
+    let batch = RecordBatch::try_new(schema.clone(), vec![id_arr, bbox_arr, geom_arr]).unwrap();
 
     let mut cols = BTreeMap::new();
     cols.insert(
@@ -542,13 +586,13 @@ fn convert_reuses_existing_bbox_column() {
 }
 
 #[test]
-fn convert_explicit_gsd_path() {
-    let tmp = TempDir::new("explicit-gsd");
+fn convert_explicit_resolution_path() {
+    let tmp = TempDir::new("explicit-resolution");
     let input = tmp.path().join("input.parquet");
     let output = tmp.path().join("out.cogp.parquet");
     write_input(&input);
     let mut args = convert_args(&input, &output);
-    args.gsd = vec![1000.0, 100.0, 10.0];
+    args.resolution = vec![1000.0, 100.0, 10.0];
     cogp::convert::run(args).unwrap();
     cogp::validate::run(&output).unwrap();
 }
@@ -561,7 +605,7 @@ fn convert_respects_render_wkb_row_group_budget() {
     write_input(&input);
 
     let mut args = convert_args(&input, &output);
-    args.gsd = vec![100_000.0];
+    args.resolution = vec![100_000.0];
     args.row_group_size = 40;
     args.row_group_max_bytes = Some(200);
     cogp::convert::run(args).unwrap();
@@ -573,9 +617,9 @@ fn convert_respects_render_wkb_row_group_budget() {
         "WKB budget must split the level"
     );
     let overview_names: Vec<&str> = reader
-        .geometry_overviews()
+        .levels()
         .iter()
-        .map(|overview| overview.column.as_str())
+        .map(|level| level.geometry_column.as_str())
         .collect();
     for row_group_index in 0..reader.num_row_groups() {
         let batches: Vec<RecordBatch> = reader

--- a/cogp-rs/tests/end_to_end.rs
+++ b/cogp-rs/tests/end_to_end.rs
@@ -20,6 +20,15 @@ use parquet::file::metadata::KeyValue;
 
 /// Little-endian WKB encoder for the geometry kinds we use in the fixture.
 mod wkb {
+    pub fn point(x: f64, y: f64) -> Vec<u8> {
+        let mut v = Vec::new();
+        v.push(1);
+        v.extend_from_slice(&1u32.to_le_bytes());
+        v.extend_from_slice(&x.to_le_bytes());
+        v.extend_from_slice(&y.to_le_bytes());
+        v
+    }
+
     pub fn polygon(corners: &[(f64, f64)]) -> Vec<u8> {
         let mut v = Vec::new();
         v.push(1);
@@ -122,6 +131,54 @@ fn write_input(path: &std::path::Path) {
     let file = File::create(path).unwrap();
     let props = parquet::file::properties::WriterProperties::builder().build();
     let mut writer = ArrowWriter::try_new(file, schema, Some(props)).unwrap();
+    writer.write(&batch).unwrap();
+    writer.append_key_value_metadata(KeyValue {
+        key: GEO_METADATA_KEY.to_string(),
+        value: Some(serde_json::to_string(&geo).unwrap()),
+    });
+    writer.close().unwrap();
+}
+
+fn write_point_input(path: &std::path::Path) {
+    let schema = Arc::new(Schema::new(vec![
+        Field::new("id", DataType::Int32, false),
+        Field::new("geometry", DataType::Binary, false),
+    ]));
+    let ids: Vec<i32> = (0..8).collect();
+    let geoms: Vec<Vec<u8>> = ids
+        .iter()
+        .map(|id| wkb::point(f64::from(*id), 0.0))
+        .collect();
+    let batch = RecordBatch::try_new(
+        schema.clone(),
+        vec![
+            Arc::new(Int32Array::from(ids)),
+            Arc::new(BinaryArray::from(
+                geoms.iter().map(Vec::as_slice).collect::<Vec<_>>(),
+            )),
+        ],
+    )
+    .unwrap();
+
+    let mut cols = BTreeMap::new();
+    cols.insert(
+        "geometry".to_string(),
+        GeoColumn {
+            encoding: "WKB".into(),
+            geometry_types: vec!["Point".into()],
+            covering: None,
+            bbox: None,
+            crs: None,
+        },
+    );
+    let geo = GeoMeta {
+        version: "1.1.0".into(),
+        primary_column: "geometry".into(),
+        columns: cols,
+    };
+
+    let file = File::create(path).unwrap();
+    let mut writer = ArrowWriter::try_new(file, schema, None).unwrap();
     writer.write(&batch).unwrap();
     writer.append_key_value_metadata(KeyValue {
         key: GEO_METADATA_KEY.to_string(),
@@ -298,6 +355,37 @@ fn convert_reader_validate_pipeline() {
             );
         }
     }
+}
+
+#[test]
+fn convert_point_uses_primary_wkb_without_overviews() {
+    let tmp = TempDir::new("point-primary-wkb");
+    let input = tmp.path().join("input.parquet");
+    let output = tmp.path().join("output.cogp.parquet");
+    write_point_input(&input);
+
+    let mut args = convert_args(&input, &output);
+    args.gsd = vec![100_000.0, 10_000.0, 1_000.0];
+    args.row_group_size = 8;
+    args.row_group_max_bytes = Some(42);
+    cogp::convert::run(args).unwrap();
+    cogp::validate::run(&output).unwrap();
+
+    let reader = Reader::open(&output).unwrap();
+    assert!(reader.geometry_overviews().is_empty());
+    assert_eq!(reader.geometry_column_for_gsd(1.0), "geometry");
+    assert!(reader.num_row_groups() > 1, "primary WKB must drive the byte budget");
+
+    let all_row_groups: Vec<usize> = (0..reader.num_row_groups()).collect();
+    let batches: Vec<RecordBatch> = reader
+        .sync_batch_reader(File::open(&output).unwrap(), &all_row_groups)
+        .unwrap()
+        .map(|batch| batch.unwrap())
+        .collect();
+    let schema = batches[0].schema();
+    assert!(schema.field_with_name("geometry").is_ok());
+    assert!(schema.fields().iter().all(|field| !field.name().starts_with("geometry_ovr_")));
+    assert_eq!(batches.iter().map(RecordBatch::num_rows).sum::<usize>(), 8);
 }
 
 #[test]

--- a/cogp-rs/tests/end_to_end.rs
+++ b/cogp-rs/tests/end_to_end.rs
@@ -139,12 +139,11 @@ fn convert_args(input: &std::path::Path, output: &std::path::Path) -> ConvertArg
         webmerc_maxzoom: 4,
         row_group_size: 8,
         row_group_max_bytes: None,
+        simplification_tolerance_factor: 1.0,
         input_units: InputUnits::Degrees,
         geometry_column: None,
         webmerc_resolution: 1024,
         point_thinning_factor: 4,
-        line_visibility_factor: 2,
-        polygon_visibility_factor: 4,
         sort_key: None,
         sort_order: SortKeyOrder::Desc,
     }
@@ -167,6 +166,24 @@ fn convert_reader_validate_pipeline() {
     assert_eq!(reader.primary_column(), "geometry");
 
     let cogp = reader.cogp_meta();
+    assert!(!cogp.geometry_overviews.is_empty());
+    assert_eq!(cogp.geometry_overviews.len(), cogp.levels.len());
+    assert!(cogp
+        .geometry_overviews
+        .iter()
+        .enumerate()
+        .all(|(level, overview)| overview.level == level));
+    let coarsest_overview = &cogp.geometry_overviews[0];
+    assert_eq!(
+        reader.geometry_column_for_gsd(cogp.levels[coarsest_overview.level].gsd),
+        coarsest_overview.column
+    );
+    let finest_overview = cogp.geometry_overviews.last().unwrap();
+    assert_eq!(finest_overview.level, cogp.levels.len() - 1);
+    assert_eq!(
+        reader.geometry_column_for_gsd(cogp.levels[finest_overview.level].gsd / 2.0),
+        finest_overview.column
+    );
     // levels list constraints (validator already checks these but assert here
     // so the reader's view stays in sync).
     let mut prev_rge: Option<i64> = None;
@@ -240,6 +257,12 @@ fn convert_reader_validate_pipeline() {
     // struct of four f64 children.
     let schema = batches[0].schema();
     let bbox_field = schema.field_with_name("bbox").unwrap();
+    for overview in &cogp.geometry_overviews {
+        let field = schema.field_with_name(&overview.column).unwrap();
+        assert_eq!(field.data_type(), &DataType::Binary);
+        assert!(field.is_nullable());
+        assert!(reader.geo_meta().columns.contains_key(&overview.column));
+    }
     match bbox_field.data_type() {
         DataType::Struct(fs) => {
             let names: Vec<&str> = fs.iter().map(|f| f.name().as_str()).collect();
@@ -249,6 +272,31 @@ fn convert_reader_validate_pipeline() {
             }
         }
         other => panic!("bbox must be a struct, got {other:?}"),
+    }
+
+    // Each overview is complete through its linked feature-level boundary and
+    // entirely NULL afterward. This lets a renderer read one projected WKB
+    // column without per-row fallback.
+    for row_group_index in 0..total_rgs {
+        let file = File::open(&output).unwrap();
+        let row_group_batches: Vec<RecordBatch> = reader
+            .sync_batch_reader(file, &[row_group_index])
+            .unwrap()
+            .map(|batch| batch.unwrap())
+            .collect();
+        for overview in &cogp.geometry_overviews {
+            let boundary = cogp.levels[overview.level].row_group_end as usize;
+            let (nulls, rows) = row_group_batches.iter().fold((0, 0), |(nulls, rows), batch| {
+                let column = batch.column_by_name(&overview.column).unwrap();
+                (nulls + column.null_count(), rows + batch.num_rows())
+            });
+            assert_eq!(
+                nulls,
+                if row_group_index <= boundary { 0 } else { rows },
+                "unexpected sparse layout for {} in row group {row_group_index}",
+                overview.column
+            );
+        }
     }
 }
 
@@ -415,4 +463,62 @@ fn convert_explicit_gsd_path() {
     args.gsd = vec![1000.0, 100.0, 10.0];
     cogp::convert::run(args).unwrap();
     cogp::validate::run(&output).unwrap();
+}
+
+#[test]
+fn convert_respects_render_wkb_row_group_budget() {
+    let tmp = TempDir::new("wkb-budget");
+    let input = tmp.path().join("input.parquet");
+    let output = tmp.path().join("out.cogp.parquet");
+    write_input(&input);
+
+    let mut args = convert_args(&input, &output);
+    args.gsd = vec![100_000.0];
+    args.row_group_size = 40;
+    args.row_group_max_bytes = Some(200);
+    cogp::convert::run(args).unwrap();
+    cogp::validate::run(&output).unwrap();
+
+    let reader = Reader::open(&output).unwrap();
+    assert!(
+        reader.num_row_groups() > 1,
+        "WKB budget must split the level"
+    );
+    let overview_names: Vec<&str> = reader
+        .geometry_overviews()
+        .iter()
+        .map(|overview| overview.column.as_str())
+        .collect();
+    for row_group_index in 0..reader.num_row_groups() {
+        let batches: Vec<RecordBatch> = reader
+            .sync_batch_reader(File::open(&output).unwrap(), &[row_group_index])
+            .unwrap()
+            .map(|batch| batch.unwrap())
+            .collect();
+        let row_count: usize = batches.iter().map(|batch| batch.num_rows()).sum();
+        let mut bytes = 0usize;
+        for batch in batches {
+            for row in 0..batch.num_rows() {
+                let largest_overview = overview_names
+                    .iter()
+                    .map(|name| {
+                        batch
+                            .column_by_name(name)
+                            .unwrap()
+                            .as_any()
+                            .downcast_ref::<BinaryArray>()
+                            .unwrap()
+                            .value(row)
+                            .len()
+                    })
+                    .max()
+                    .unwrap();
+                bytes += largest_overview;
+            }
+        }
+        assert!(
+            bytes <= 200 || row_count == 1,
+            "row group {row_group_index} has {bytes} render WKB bytes across {row_count} rows"
+        );
+    }
 }

--- a/cogp-rs/tests/validate_failures.rs
+++ b/cogp-rs/tests/validate_failures.rs
@@ -10,8 +10,8 @@ use std::sync::Arc;
 use arrow::array::{ArrayRef, Float64Array, RecordBatch, StructArray};
 use arrow::datatypes::{DataType, Field, Fields, Schema};
 use cogp::meta::{
-    BboxCovering, CogpMeta, Covering, GeoColumn, GeoMeta, Level, COGP_METADATA_KEY, COGP_VERSION,
-    GEOPARQUET_VERSION, GEO_METADATA_KEY,
+    BboxCovering, CogpMeta, Covering, GeoColumn, GeoMeta, GeometryOverview, Level,
+    COGP_METADATA_KEY, COGP_VERSION, GEOPARQUET_VERSION, GEO_METADATA_KEY,
 };
 use parquet::arrow::ArrowWriter;
 use parquet::file::metadata::KeyValue;
@@ -151,9 +151,16 @@ fn validate_happy_path_accepts_well_formed_file() {
     let cogp = CogpMeta {
         version: COGP_VERSION.into(),
         levels: vec![
-            Level { row_group_end: 0, gsd: 1000.0 },
-            Level { row_group_end: 2, gsd: 100.0 },
+            Level {
+                row_group_end: 0,
+                gsd: 1000.0,
+            },
+            Level {
+                row_group_end: 2,
+                gsd: 100.0,
+            },
         ],
+        geometry_overviews: vec![],
     };
     write_file(&p, 3, kv(Some(standard_geo()), Some(cogp)));
     cogp::validate::run(&p).unwrap();
@@ -165,7 +172,11 @@ fn validate_rejects_missing_geo() {
     let p = tmp.path().join("bad.parquet");
     let cogp = CogpMeta {
         version: COGP_VERSION.into(),
-        levels: vec![Level { row_group_end: 0, gsd: 1.0 }],
+        levels: vec![Level {
+            row_group_end: 0,
+            gsd: 1.0,
+        }],
+        geometry_overviews: vec![],
     };
     write_file(&p, 1, kv(None, Some(cogp)));
     assert_validate_fails(&p, "geo");
@@ -186,10 +197,17 @@ fn validate_rejects_non_decreasing_gsd() {
     let cogp = CogpMeta {
         version: COGP_VERSION.into(),
         levels: vec![
-            Level { row_group_end: 0, gsd: 100.0 },
+            Level {
+                row_group_end: 0,
+                gsd: 100.0,
+            },
             // equal to previous → must be strictly less
-            Level { row_group_end: 1, gsd: 100.0 },
+            Level {
+                row_group_end: 1,
+                gsd: 100.0,
+            },
         ],
+        geometry_overviews: vec![],
     };
     write_file(&p, 2, kv(Some(standard_geo()), Some(cogp)));
     assert_validate_fails(&p, "gsd");
@@ -202,9 +220,16 @@ fn validate_rejects_non_increasing_row_group_end() {
     let cogp = CogpMeta {
         version: COGP_VERSION.into(),
         levels: vec![
-            Level { row_group_end: 1, gsd: 100.0 },
-            Level { row_group_end: 1, gsd: 10.0 }, // not strictly greater
+            Level {
+                row_group_end: 1,
+                gsd: 100.0,
+            },
+            Level {
+                row_group_end: 1,
+                gsd: 10.0,
+            }, // not strictly greater
         ],
+        geometry_overviews: vec![],
     };
     write_file(&p, 2, kv(Some(standard_geo()), Some(cogp)));
     assert_validate_fails(&p, "row_group_end");
@@ -218,9 +243,16 @@ fn validate_rejects_final_row_group_end_mismatch() {
     let cogp = CogpMeta {
         version: COGP_VERSION.into(),
         levels: vec![
-            Level { row_group_end: 0, gsd: 100.0 },
-            Level { row_group_end: 1, gsd: 10.0 },
+            Level {
+                row_group_end: 0,
+                gsd: 100.0,
+            },
+            Level {
+                row_group_end: 1,
+                gsd: 10.0,
+            },
         ],
+        geometry_overviews: vec![],
     };
     write_file(&p, 3, kv(Some(standard_geo()), Some(cogp)));
     assert_validate_fails(&p, "num_row_groups");
@@ -232,7 +264,11 @@ fn validate_rejects_negative_gsd() {
     let p = tmp.path().join("bad.parquet");
     let cogp = CogpMeta {
         version: COGP_VERSION.into(),
-        levels: vec![Level { row_group_end: 0, gsd: -1.0 }],
+        levels: vec![Level {
+            row_group_end: 0,
+            gsd: -1.0,
+        }],
+        geometry_overviews: vec![],
     };
     write_file(&p, 1, kv(Some(standard_geo()), Some(cogp)));
     assert_validate_fails(&p, "positive");
@@ -254,7 +290,11 @@ fn validate_rejects_missing_covering_column_in_schema() {
     });
     let cogp = CogpMeta {
         version: COGP_VERSION.into(),
-        levels: vec![Level { row_group_end: 0, gsd: 1.0 }],
+        levels: vec![Level {
+            row_group_end: 0,
+            gsd: 1.0,
+        }],
+        geometry_overviews: vec![],
     };
     write_file(&p, 1, kv(Some(geo), Some(cogp)));
     assert_validate_fails(&p, "covering");
@@ -267,7 +307,67 @@ fn validate_rejects_empty_levels() {
     let cogp = CogpMeta {
         version: COGP_VERSION.into(),
         levels: vec![],
+        geometry_overviews: vec![],
     };
     write_file(&p, 1, kv(Some(standard_geo()), Some(cogp)));
     assert_validate_fails(&p, "non-empty");
+}
+
+#[test]
+fn validate_rejects_mixed_geometry_families() {
+    let tmp = TempDir::new("mixed-geometry-families");
+    let p = tmp.path().join("bad.parquet");
+    let mut geo = standard_geo();
+    geo.columns.get_mut("geometry").unwrap().geometry_types =
+        vec!["LineString".into(), "Polygon".into()];
+    let cogp = CogpMeta {
+        version: COGP_VERSION.into(),
+        levels: vec![Level {
+            row_group_end: 0,
+            gsd: 1.0,
+        }],
+        geometry_overviews: vec![],
+    };
+    write_file(&p, 1, kv(Some(geo), Some(cogp)));
+    assert_validate_fails(&p, "exactly one Point, Line, or Polygon family");
+}
+
+#[test]
+fn validate_rejects_overview_link_to_missing_level() {
+    let tmp = TempDir::new("bad-overview-level");
+    let p = tmp.path().join("bad.parquet");
+    let cogp = CogpMeta {
+        version: COGP_VERSION.into(),
+        levels: vec![Level {
+            row_group_end: 0,
+            gsd: 1.0,
+        }],
+        geometry_overviews: vec![GeometryOverview {
+            column: "geometry_ovr_0".into(),
+            level: 1,
+            tolerance_meters: 1.0,
+        }],
+    };
+    write_file(&p, 1, kv(Some(standard_geo()), Some(cogp)));
+    assert_validate_fails(&p, "out of range");
+}
+
+#[test]
+fn validate_rejects_non_positive_overview_tolerance() {
+    let tmp = TempDir::new("bad-overview-tolerance");
+    let p = tmp.path().join("bad.parquet");
+    let cogp = CogpMeta {
+        version: COGP_VERSION.into(),
+        levels: vec![Level {
+            row_group_end: 0,
+            gsd: 1.0,
+        }],
+        geometry_overviews: vec![GeometryOverview {
+            column: "geometry_ovr_0".into(),
+            level: 0,
+            tolerance_meters: 0.0,
+        }],
+    };
+    write_file(&p, 1, kv(Some(standard_geo()), Some(cogp)));
+    assert_validate_fails(&p, "tolerance_meters=0 must be positive");
 }

--- a/cogp-rs/tests/validate_failures.rs
+++ b/cogp-rs/tests/validate_failures.rs
@@ -7,11 +7,11 @@ use std::fs::File;
 use std::path::PathBuf;
 use std::sync::Arc;
 
-use arrow::array::{ArrayRef, Float64Array, RecordBatch, StructArray};
+use arrow::array::{ArrayRef, BinaryArray, Float64Array, RecordBatch, StructArray};
 use arrow::datatypes::{DataType, Field, Fields, Schema};
 use cogp::meta::{
-    BboxCovering, CogpMeta, Covering, GeoColumn, GeoMeta, GeometryOverview, Level,
-    COGP_METADATA_KEY, COGP_VERSION, GEOPARQUET_VERSION, GEO_METADATA_KEY,
+    BboxCovering, CogpMeta, Covering, GeoColumn, GeoMeta, Level, COGP_METADATA_KEY, COGP_VERSION,
+    GEOPARQUET_VERSION, GEO_METADATA_KEY,
 };
 use parquet::arrow::ArrowWriter;
 use parquet::file::metadata::KeyValue;
@@ -77,15 +77,22 @@ fn standard_geo() -> GeoMeta {
     }
 }
 
+fn level(row_group_end: i64, resolution_meters: f64) -> Level {
+    Level {
+        row_group_end,
+        resolution_meters,
+        geometry_column: "geometry".into(),
+    }
+}
+
 /// Write `row_groups` row groups, each with a single row in the bbox struct.
 /// All four sub-columns have non-null values so Parquet always emits min/max
 /// statistics for them. The KV metadata is whatever the caller passes.
 fn write_file(path: &std::path::Path, row_groups: usize, kv: Vec<KeyValue>) {
-    let schema = Arc::new(Schema::new(vec![Field::new(
-        "bbox",
-        DataType::Struct(bbox_struct_fields()),
-        false,
-    )]));
+    let schema = Arc::new(Schema::new(vec![
+        Field::new("bbox", DataType::Struct(bbox_struct_fields()), false),
+        Field::new("geometry", DataType::Binary, false),
+    ]));
     let props = WriterProperties::builder()
         .set_max_row_group_size(1) // one row per row group
         .build();
@@ -106,7 +113,8 @@ fn write_file(path: &std::path::Path, row_groups: usize, kv: Vec<KeyValue>) {
             )
             .unwrap(),
         );
-        let batch = RecordBatch::try_new(schema.clone(), vec![bbox]).unwrap();
+        let geometry: ArrayRef = Arc::new(BinaryArray::from(vec![&[1_u8][..]]));
+        let batch = RecordBatch::try_new(schema.clone(), vec![bbox, geometry]).unwrap();
         writer.write(&batch).unwrap();
         writer.flush().unwrap();
     }
@@ -150,17 +158,7 @@ fn validate_happy_path_accepts_well_formed_file() {
     let p = tmp.path().join("ok.parquet");
     let cogp = CogpMeta {
         version: COGP_VERSION.into(),
-        levels: vec![
-            Level {
-                row_group_end: 0,
-                gsd: 1000.0,
-            },
-            Level {
-                row_group_end: 2,
-                gsd: 100.0,
-            },
-        ],
-        geometry_overviews: vec![],
+        levels: vec![level(0, 1000.0), level(2, 100.0)],
     };
     write_file(&p, 3, kv(Some(standard_geo()), Some(cogp)));
     cogp::validate::run(&p).unwrap();
@@ -172,11 +170,7 @@ fn validate_rejects_missing_geo() {
     let p = tmp.path().join("bad.parquet");
     let cogp = CogpMeta {
         version: COGP_VERSION.into(),
-        levels: vec![Level {
-            row_group_end: 0,
-            gsd: 1.0,
-        }],
-        geometry_overviews: vec![],
+        levels: vec![level(0, 1.0)],
     };
     write_file(&p, 1, kv(None, Some(cogp)));
     assert_validate_fails(&p, "geo");
@@ -191,26 +185,15 @@ fn validate_rejects_missing_cogp() {
 }
 
 #[test]
-fn validate_rejects_non_decreasing_gsd() {
-    let tmp = TempDir::new("flat-gsd");
+fn validate_rejects_non_decreasing_resolution() {
+    let tmp = TempDir::new("flat-resolution");
     let p = tmp.path().join("bad.parquet");
     let cogp = CogpMeta {
         version: COGP_VERSION.into(),
-        levels: vec![
-            Level {
-                row_group_end: 0,
-                gsd: 100.0,
-            },
-            // equal to previous → must be strictly less
-            Level {
-                row_group_end: 1,
-                gsd: 100.0,
-            },
-        ],
-        geometry_overviews: vec![],
+        levels: vec![level(0, 100.0), level(1, 100.0)],
     };
     write_file(&p, 2, kv(Some(standard_geo()), Some(cogp)));
-    assert_validate_fails(&p, "gsd");
+    assert_validate_fails(&p, "resolution_meters");
 }
 
 #[test]
@@ -219,17 +202,7 @@ fn validate_rejects_non_increasing_row_group_end() {
     let p = tmp.path().join("bad.parquet");
     let cogp = CogpMeta {
         version: COGP_VERSION.into(),
-        levels: vec![
-            Level {
-                row_group_end: 1,
-                gsd: 100.0,
-            },
-            Level {
-                row_group_end: 1,
-                gsd: 10.0,
-            }, // not strictly greater
-        ],
-        geometry_overviews: vec![],
+        levels: vec![level(1, 100.0), level(1, 10.0)],
     };
     write_file(&p, 2, kv(Some(standard_geo()), Some(cogp)));
     assert_validate_fails(&p, "row_group_end");
@@ -242,33 +215,19 @@ fn validate_rejects_final_row_group_end_mismatch() {
     // File has 3 row groups, but levels stop at index 1 → 2 ≠ 3-1.
     let cogp = CogpMeta {
         version: COGP_VERSION.into(),
-        levels: vec![
-            Level {
-                row_group_end: 0,
-                gsd: 100.0,
-            },
-            Level {
-                row_group_end: 1,
-                gsd: 10.0,
-            },
-        ],
-        geometry_overviews: vec![],
+        levels: vec![level(0, 100.0), level(1, 10.0)],
     };
     write_file(&p, 3, kv(Some(standard_geo()), Some(cogp)));
     assert_validate_fails(&p, "num_row_groups");
 }
 
 #[test]
-fn validate_rejects_negative_gsd() {
-    let tmp = TempDir::new("neg-gsd");
+fn validate_rejects_negative_resolution() {
+    let tmp = TempDir::new("neg-resolution");
     let p = tmp.path().join("bad.parquet");
     let cogp = CogpMeta {
         version: COGP_VERSION.into(),
-        levels: vec![Level {
-            row_group_end: 0,
-            gsd: -1.0,
-        }],
-        geometry_overviews: vec![],
+        levels: vec![level(0, -1.0)],
     };
     write_file(&p, 1, kv(Some(standard_geo()), Some(cogp)));
     assert_validate_fails(&p, "positive");
@@ -290,11 +249,7 @@ fn validate_rejects_missing_covering_column_in_schema() {
     });
     let cogp = CogpMeta {
         version: COGP_VERSION.into(),
-        levels: vec![Level {
-            row_group_end: 0,
-            gsd: 1.0,
-        }],
-        geometry_overviews: vec![],
+        levels: vec![level(0, 1.0)],
     };
     write_file(&p, 1, kv(Some(geo), Some(cogp)));
     assert_validate_fails(&p, "covering");
@@ -307,7 +262,6 @@ fn validate_rejects_empty_levels() {
     let cogp = CogpMeta {
         version: COGP_VERSION.into(),
         levels: vec![],
-        geometry_overviews: vec![],
     };
     write_file(&p, 1, kv(Some(standard_geo()), Some(cogp)));
     assert_validate_fails(&p, "non-empty");
@@ -322,52 +276,38 @@ fn validate_rejects_mixed_geometry_families() {
         vec!["LineString".into(), "Polygon".into()];
     let cogp = CogpMeta {
         version: COGP_VERSION.into(),
-        levels: vec![Level {
-            row_group_end: 0,
-            gsd: 1.0,
-        }],
-        geometry_overviews: vec![],
+        levels: vec![level(0, 1.0)],
     };
     write_file(&p, 1, kv(Some(geo), Some(cogp)));
     assert_validate_fails(&p, "exactly one Point, Line, or Polygon family");
 }
 
 #[test]
-fn validate_rejects_overview_link_to_missing_level() {
-    let tmp = TempDir::new("bad-overview-level");
+fn validate_rejects_missing_level_geometry_column() {
+    let tmp = TempDir::new("missing-level-geometry");
     let p = tmp.path().join("bad.parquet");
     let cogp = CogpMeta {
         version: COGP_VERSION.into(),
         levels: vec![Level {
-            row_group_end: 0,
-            gsd: 1.0,
-        }],
-        geometry_overviews: vec![GeometryOverview {
-            column: "geometry_ovr_0".into(),
-            level: 1,
-            tolerance_meters: 1.0,
+            geometry_column: "missing_geometry".into(),
+            ..level(0, 1.0)
         }],
     };
     write_file(&p, 1, kv(Some(standard_geo()), Some(cogp)));
-    assert_validate_fails(&p, "out of range");
+    assert_validate_fails(&p, "missing from `geo.columns`");
 }
 
 #[test]
-fn validate_rejects_non_positive_overview_tolerance() {
-    let tmp = TempDir::new("bad-overview-tolerance");
+fn validate_rejects_empty_level_geometry_column() {
+    let tmp = TempDir::new("empty-level-geometry");
     let p = tmp.path().join("bad.parquet");
     let cogp = CogpMeta {
         version: COGP_VERSION.into(),
         levels: vec![Level {
-            row_group_end: 0,
-            gsd: 1.0,
-        }],
-        geometry_overviews: vec![GeometryOverview {
-            column: "geometry_ovr_0".into(),
-            level: 0,
-            tolerance_meters: 0.0,
+            geometry_column: String::new(),
+            ..level(0, 1.0)
         }],
     };
     write_file(&p, 1, kv(Some(standard_geo()), Some(cogp)));
-    assert_validate_fails(&p, "tolerance_meters=0 must be positive");
+    assert_validate_fails(&p, "non-empty string");
 }


### PR DESCRIPTION
## Summary

- evolve the draft profile to v0.2 with optional scale-specific WKB overview columns and single-family geometry files
- derive a deterministic half-resolution GSD ladder, assign Line/Polygon visibility from simplification viability, and select the retained hierarchy from simplified WKB payload growth
- size row groups against rendering WKB, add overview-aware Rust/TypeScript readers and validation, and fall back to the lossless primary WKB when no overview exists
- make demo viewport reads geometry-only with lazy property loading, range coalescing, transfer diagnostics, and a bounded exact-range LRU cache

## Why

Large LineString and Polygon datasets made low-zoom reads depend on raw, lossless WKB and on opinionated fixed level counts. Dense line datasets also caused repeated large range requests whenever the viewport moved slightly. The new hierarchy is based on the geometry that rendering clients actually read, while preserving the primary geometry unchanged for lossless use.

## Impact

Converters now build only the useful overview hierarchy and split row groups using rendering payload. Readers select one sufficiently precise overview column, avoid unrelated columns during viewport reads, and reuse repeated byte ranges. Existing COGP files without geometry overviews remain readable: Line and Polygon reads use the primary raw WKB column.

## Validation

- `cargo test`
- `npm test` in `cogp-js`
- `npm --prefix demo run build` in `cogp-js`
- `git diff --check`
