### PR TITLE
Add page-index-aware range I/O

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -476,6 +476,7 @@ dependencies = [
  "rayon",
  "serde",
  "serde_json",
+ "thrift",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -461,7 +461,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cogp"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "arrow",

--- a/README.md
+++ b/README.md
@@ -48,9 +48,9 @@ https://github.com/user-attachments/assets/7daf178e-28b0-4440-845d-ee8f74fa5062
 
 ## Sample data
 
-- [pois.cogp.parquet](https://cogp-demo.spatialty.io/pois.cogp.parquet) (OpenStreetMap)
-- [segments.cogp.parquet](https://cogp-demo.spatialty.io/segments.cogp.parquet) (OvertureMaps)
-- [buildings.cogp.parquet](https://cogp-demo.spatialty.io/buildings.cogp.parquet) (OvertureMaps)
+- [pois.cogp.parquet](https://cogp-demo.spatialty.io/v0.1.1/pois.cogp.parquet) (OpenStreetMap)
+- [segments.cogp.parquet](https://cogp-demo.spatialty.io/v0.1.1/segments.cogp.parquet) (OvertureMaps)
+- [buildings.cogp.parquet](https://cogp-demo.spatialty.io/v0.1.1/buildings.cogp.parquet) (OvertureMaps)
 
 ## When COGP works well
 
@@ -101,7 +101,7 @@ A proof-of-concept exploring this layout exists at [Kanahiro/yosegi](https://git
 
 ## Status and feedback
 
-COGP v0.1 is an early draft. Feedback, issues, and discussion are welcome via GitHub Issues.
+COGP v0.1.1 is an early draft. Feedback, issues, and discussion are welcome via GitHub Issues.
 
 ## License
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -1,6 +1,6 @@
 ---
 title: Cloud Optimized GeoParquet Profile (COGP)
-version: "0.1.0"
+version: "0.1.1"
 status: Draft
 scope: A cloud-optimized progressive rendering profile for GeoParquet 1.1
 license: CC BY 4.0
@@ -86,7 +86,7 @@ This value is rendering-oriented. It does not guarantee positional accuracy, top
 
 ## 5. Requirements
 
-A COGP v0.1 file MUST satisfy the following requirements.
+A COGP v0.1.1 file MUST satisfy the following requirements.
 
 ### 5.1 GeoParquet compatibility
 
@@ -102,7 +102,7 @@ where `<primary_column>` is the value of the GeoParquet `primary_column` field.
 
 Each of the bounding box columns (`xmin`, `ymin`, `xmax`, `ymax`) referenced by this covering MUST have Parquet row group min/max statistics present, so that readers can perform spatial pruning at row group granularity.
 
-For COGP v0.1, geometries in the primary geometry column MUST NOT cross the antimeridian in a way that makes GeoParquet bbox covering unsuitable for spatial pruning. Producers SHOULD split such geometries or use another representation before writing a COGP file.
+For COGP v0.1.1, geometries in the primary geometry column MUST NOT cross the antimeridian in a way that makes GeoParquet bbox covering unsuitable for spatial pruning. Producers SHOULD split such geometries or use another representation before writing a COGP file.
 
 ### 5.2 Physical ordering
 
@@ -178,7 +178,7 @@ Readers MUST NOT interpret `cogp` metadata with an unsupported major version as 
 
 ```json
 {
-  "version": "0.1.0",
+  "version": "0.1.1",
   "levels": [
     {
       "row_group_end": 0,

--- a/cogp-js/README.md
+++ b/cogp-js/README.md
@@ -4,22 +4,42 @@ TypeScript reader for the [Cloud Optimized GeoParquet Profile
 (COGP)](https://github.com/Kanahiro/cloud-optimized-geoparquet). It reads COGP
 metadata and fetches only the Parquet ranges needed for a requested geographic
 area and ground sample distance. Bbox reads use covering-column statistics to
-prune row groups, then apply an exact per-feature bbox filter to the surviving
-rows.
+prune row groups, then lazily fetch Parquet PageIndexes to prune pages inside
+the surviving groups. Files without PageIndexes fall back safely to Row Group
+reads. An exact per-feature bbox filter is applied to every surviving row.
 
 Remote reads coalesce nearby concurrent byte ranges by default. This reduces
-HTTP request count while bounding extra transfer to a
-128 KiB gap and total fetched bytes to 1.25× the uniquely requested bytes. Tune
-or disable it when opening:
+HTTP request count with three absolute bounds: a 32 KiB maximum gap, 128 KiB of
+cumulative extra bytes per merged request, and a 2 MiB maximum merged request.
+Absolute byte budgets behave consistently for both tiny PageIndex reads and
+large data pages. PageIndexes are prefetched in bounded 16-RowGroup planning
+windows. Page-pruned bbox decode batches run with concurrency 4 so adjacent
+RowGroups do not serialize their HTTP requests; unfiltered reads remain serial
+to bound memory. Tune or disable coalescing when opening:
 
 ```ts
 await CogpReader.open(url, {
   rangeCoalescing: {
     maxGapBytes: 64 * 1024,
-    maxOverfetchRatio: 1.25,
+    maxExtraBytes: 256 * 1024,
+    maxRequestBytes: 2 * 1024 * 1024,
   },
 });
 await CogpReader.open(url, { rangeCoalescing: false });
+```
+
+`CogpReader.open()` forces Fetch's cache mode to `no-store`, including footer
+and byte-range requests. Other standard Fetch options can be supplied through
+`requestInit`; the cache mode cannot be overridden.
+
+Each reader keeps a containment-aware LRU of successful compressed ranges in
+memory. The default limit is 64 MiB; duplicate in-flight reads share one
+request, failed reads are retryable, and a cached larger range can satisfy a
+smaller slice. Configure or disable it when opening:
+
+```ts
+await CogpReader.open(url, { rangeCache: { maxBytes: 32 * 1024 * 1024 } });
+await CogpReader.open(url, { rangeCache: false });
 ```
 
 ## Development

--- a/cogp-js/demo/index.html
+++ b/cogp-js/demo/index.html
@@ -31,13 +31,13 @@
         Preset
         <select id="preset">
           <option value="">-- choose a sample --</option>
-          <option value="https://cogp-demo.spatialty.io/pois.cogp.parquet">
+          <option value="https://cogp-demo.spatialty.io/v0.1.1/pois.cogp.parquet">
             POIs (OSM)
           </option>
-          <option value="https://cogp-demo.spatialty.io/segments.cogp.parquet">
+          <option value="https://cogp-demo.spatialty.io/v0.1.1/segments.cogp.parquet">
             Road segments (OvertureMaps)
           </option>
-          <option value="https://cogp-demo.spatialty.io/buildings.cogp.parquet">
+          <option value="https://cogp-demo.spatialty.io/v0.1.1/buildings.cogp.parquet">
             Buildings (OvertureMaps)
           </option>
         </select>

--- a/cogp-js/demo/package.json
+++ b/cogp-js/demo/package.json
@@ -1,7 +1,7 @@
 {
   "name": "cogp-demo",
   "private": true,
-  "version": "0.0.0",
+  "version": "0.1.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/cogp-js/package.json
+++ b/cogp-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cogp",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Cloud Optimized GeoParquet Profile (COGP) reader for the web.",
   "license": "MIT",
   "type": "module",

--- a/cogp-js/src/coalescing-buffer.ts
+++ b/cogp-js/src/coalescing-buffer.ts
@@ -4,10 +4,12 @@ export interface AsyncBufferLike {
 }
 
 export interface RangeCoalescingOptions {
-  /** Maximum unrequested gap included to eliminate one range request. */
+  /** Maximum single unrequested gap included in a merged request. */
   maxGapBytes?: number;
-  /** Maximum merged bytes / uniquely requested bytes; must be at least 1. */
-  maxOverfetchRatio?: number;
+  /** Maximum cumulative unrequested bytes included in one merged request. */
+  maxExtraBytes?: number;
+  /** Maximum byte length of a merged request. Individual source reads may be larger. */
+  maxRequestBytes?: number;
 }
 
 interface PendingSlice {
@@ -20,12 +22,13 @@ interface PendingSlice {
 interface SliceRun {
   start: number;
   end: number;
-  requestedBytes: number;
+  extraBytes: number;
   slices: PendingSlice[];
 }
 
-const DEFAULT_MAX_GAP_BYTES = 128 * 1024;
-const DEFAULT_MAX_OVERFETCH_RATIO = 1.25;
+const DEFAULT_MAX_GAP_BYTES = 32 * 1024;
+const DEFAULT_MAX_EXTRA_BYTES = 128 * 1024;
+const DEFAULT_MAX_REQUEST_BYTES = 2 * 1024 * 1024;
 
 /**
  * Batch concurrent AsyncBuffer slices into nearby contiguous reads.
@@ -33,21 +36,21 @@ const DEFAULT_MAX_OVERFETCH_RATIO = 1.25;
  * Parquet page pruning can issue one small slice per physical column and row
  * group. Waiting until the current microtask finishes exposes that batch
  * without adding a timer delay. Nearby slices are fetched as one ordinary HTTP
- * Range and split back into exact per-caller buffers. The gap limit makes the
- * request-count/extra-byte tradeoff explicit and bounded.
+ * Range and split back into exact per-caller buffers. Three absolute byte
+ * budgets bound the tradeoff: a single hole, all holes in one request, and
+ * the merged request itself. Absolute limits remain predictable for both tiny
+ * PageIndex reads and large data pages; a ratio does not.
  */
 export function coalescingAsyncBuffer(
   source: AsyncBufferLike,
   options: RangeCoalescingOptions = {},
 ): AsyncBufferLike {
   const maxGapBytes = options.maxGapBytes ?? DEFAULT_MAX_GAP_BYTES;
-  const maxOverfetchRatio = options.maxOverfetchRatio ?? DEFAULT_MAX_OVERFETCH_RATIO;
-  if (!Number.isSafeInteger(maxGapBytes) || maxGapBytes < 0) {
-    throw new Error(`maxGapBytes must be a non-negative safe integer, got ${maxGapBytes}`);
-  }
-  if (!Number.isFinite(maxOverfetchRatio) || maxOverfetchRatio < 1) {
-    throw new Error(`maxOverfetchRatio must be a finite number >= 1, got ${maxOverfetchRatio}`);
-  }
+  const maxExtraBytes = options.maxExtraBytes ?? DEFAULT_MAX_EXTRA_BYTES;
+  const maxRequestBytes = options.maxRequestBytes ?? DEFAULT_MAX_REQUEST_BYTES;
+  validateByteBudget('maxGapBytes', maxGapBytes, true);
+  validateByteBudget('maxExtraBytes', maxExtraBytes, true);
+  validateByteBudget('maxRequestBytes', maxRequestBytes, false);
 
   let pending: PendingSlice[] = [];
   let flushScheduled = false;
@@ -56,7 +59,7 @@ export function coalescingAsyncBuffer(
     flushScheduled = false;
     const batch = pending;
     pending = [];
-    const runs = makeRuns(batch, maxGapBytes, maxOverfetchRatio);
+    const runs = makeRuns(batch, maxGapBytes, maxExtraBytes, maxRequestBytes);
     for (const run of runs) void fetchRun(source, run);
   };
 
@@ -88,7 +91,8 @@ export function coalescingAsyncBuffer(
 function makeRuns(
   batch: PendingSlice[],
   maxGapBytes: number,
-  maxOverfetchRatio: number,
+  maxExtraBytes: number,
+  maxRequestBytes: number,
 ): SliceRun[] {
   const sorted = batch.sort((a, b) => a.start - b.start || a.end - b.end);
   const runs: SliceRun[] = [];
@@ -98,37 +102,44 @@ function makeRuns(
       runs.push({
         start: slice.start,
         end: slice.end,
-        requestedBytes: slice.end - slice.start,
+        extraBytes: 0,
         slices: [slice],
       });
       continue;
     }
 
-    const gap = slice.start - run.end;
+    const gap = Math.max(0, slice.start - run.end);
     const mergedEnd = Math.max(run.end, slice.end);
     const mergedSpan = mergedEnd - run.start;
-    const addedRequestedBytes = Math.max(0, slice.end - Math.max(slice.start, run.end));
-    const mergedRequestedBytes = run.requestedBytes + addedRequestedBytes;
-    const overfetchRatio = mergedSpan / mergedRequestedBytes;
+    const mergedExtraBytes = run.extraBytes + gap;
     // Overlapping ranges never add transfer bytes, so merge them even when an
     // individual request is already larger than either configured budget.
     if (
-      gap <= 0 ||
-      (gap <= maxGapBytes && overfetchRatio <= maxOverfetchRatio)
+      gap === 0 ||
+      (gap <= maxGapBytes &&
+        mergedExtraBytes <= maxExtraBytes &&
+        mergedSpan <= maxRequestBytes)
     ) {
       run.end = mergedEnd;
-      run.requestedBytes = mergedRequestedBytes;
+      run.extraBytes = mergedExtraBytes;
       run.slices.push(slice);
     } else {
       runs.push({
         start: slice.start,
         end: slice.end,
-        requestedBytes: slice.end - slice.start,
+        extraBytes: 0,
         slices: [slice],
       });
     }
   }
   return runs;
+}
+
+function validateByteBudget(name: string, value: number, allowZero: boolean): void {
+  if (!Number.isSafeInteger(value) || value < (allowZero ? 0 : 1)) {
+    const requirement = allowZero ? 'a non-negative' : 'a positive';
+    throw new Error(`${name} must be ${requirement} safe integer, got ${value}`);
+  }
 }
 
 async function fetchRun(source: AsyncBufferLike, run: SliceRun): Promise<void> {

--- a/cogp-js/src/index.ts
+++ b/cogp-js/src/index.ts
@@ -5,6 +5,8 @@ export type {
   ReadOptions,
 } from './reader.js';
 export type { RangeCoalescingOptions } from './coalescing-buffer.js';
+export { rangeCachedAsyncBuffer } from './range-cache.js';
+export type { RangeCacheOptions } from './range-cache.js';
 
 export {
   COGP_METADATA_KEY,

--- a/cogp-js/src/range-cache.ts
+++ b/cogp-js/src/range-cache.ts
@@ -1,0 +1,140 @@
+import type { AsyncBufferLike } from './coalescing-buffer.js';
+
+export interface RangeCacheOptions {
+  /** Maximum compressed bytes retained by one reader. Defaults to 64 MiB. */
+  maxBytes?: number;
+}
+
+interface CacheEntry {
+  start: number;
+  end: number;
+  bytes: number;
+  settled: boolean;
+  promise: Promise<ArrayBuffer>;
+}
+
+const DEFAULT_MAX_BYTES = 64 * 1024 * 1024;
+
+/**
+ * Cache successful byte ranges for the lifetime of one AsyncBuffer.
+ *
+ * Entries are containment-aware: a cached range can satisfy any smaller
+ * slice inside it. Promise values are inserted immediately so duplicate
+ * in-flight reads share the same request. Settled entries follow LRU order;
+ * in-flight entries may temporarily exceed the budget but are never evicted.
+ */
+export function rangeCachedAsyncBuffer(
+  source: AsyncBufferLike,
+  options: RangeCacheOptions = {},
+): AsyncBufferLike {
+  const maxBytes = options.maxBytes ?? DEFAULT_MAX_BYTES;
+  if (!Number.isSafeInteger(maxBytes) || maxBytes < 0) {
+    throw new Error(`maxBytes must be a non-negative safe integer, got ${maxBytes}`);
+  }
+
+  // Set insertion order is the LRU list: hits are removed and re-added.
+  const entries = new Set<CacheEntry>();
+  let cachedBytes = 0;
+
+  const remove = (entry: CacheEntry): void => {
+    if (!entries.delete(entry)) return;
+    cachedBytes -= entry.bytes;
+  };
+
+  const touch = (entry: CacheEntry): void => {
+    entries.delete(entry);
+    entries.add(entry);
+  };
+
+  const evict = (): void => {
+    if (cachedBytes <= maxBytes) return;
+    for (const entry of entries.values()) {
+      if (!entry.settled) continue;
+      remove(entry);
+      if (cachedBytes <= maxBytes) return;
+    }
+  };
+
+  const findContainer = (start: number, end: number): CacheEntry | undefined => {
+    let best: CacheEntry | undefined;
+    for (const entry of entries.values()) {
+      if (entry.start > start || end > entry.end) continue;
+      if (!best || entry.bytes < best.bytes) best = entry;
+    }
+    if (best) touch(best);
+    return best;
+  };
+
+  const fetchWithoutCaching = (start: number, end: number): Promise<ArrayBuffer> => {
+    try {
+      return Promise.resolve(source.slice(start, end));
+    } catch (error) {
+      return Promise.reject(error);
+    }
+  };
+
+  return {
+    byteLength: source.byteLength,
+    slice(start: number, end = source.byteLength): Promise<ArrayBuffer> {
+      if (!Number.isSafeInteger(start) || !Number.isSafeInteger(end)) {
+        return Promise.reject(new Error(`slice bounds must be safe integers, got [${start}, ${end})`));
+      }
+      if (start < 0 || end < start || end > source.byteLength) {
+        return Promise.reject(
+          new Error(`slice [${start}, ${end}) is outside buffer length ${source.byteLength}`),
+        );
+      }
+      if (start === end) return Promise.resolve(new ArrayBuffer(0));
+
+      const container = findContainer(start, end);
+      if (container) {
+        return container.promise.then(buffer =>
+          buffer.slice(start - container.start, end - container.start),
+        );
+      }
+
+      const bytes = end - start;
+      if (maxBytes === 0 || bytes > maxBytes) return fetchWithoutCaching(start, end);
+
+      let fetched: Promise<ArrayBuffer>;
+      try {
+        fetched = Promise.resolve(source.slice(start, end));
+      } catch (error) {
+        return Promise.reject(error);
+      }
+
+      let entry!: CacheEntry;
+      const promise = fetched.then(buffer => {
+        if (buffer.byteLength < bytes) {
+          throw new Error(
+            `source returned ${buffer.byteLength} bytes for [${start}, ${end}), expected ${bytes}`,
+          );
+        }
+        entry.settled = true;
+        // A newly completed superset makes older contained entries redundant.
+        for (const other of entries.values()) {
+          if (
+            other !== entry &&
+            other.settled &&
+            start <= other.start &&
+            other.end <= end
+          ) {
+            remove(other);
+          }
+        }
+        evict();
+        return buffer.byteLength === bytes ? buffer : buffer.slice(0, bytes);
+      }).catch(error => {
+        remove(entry);
+        throw error;
+      });
+      entry = { start, end, bytes, settled: false, promise };
+      entries.add(entry);
+      cachedBytes += bytes;
+      evict();
+
+      // Never expose the cached ArrayBuffer itself to mutable callers.
+      return promise.then(buffer => buffer.slice(0));
+    },
+  };
+}

--- a/cogp-js/src/reader.ts
+++ b/cogp-js/src/reader.ts
@@ -1,6 +1,7 @@
 import { asyncBufferFromUrl, parquetMetadataAsync, parquetReadObjects } from 'hyparquet';
 import { compressors } from 'hyparquet-compressors';
 import { DEFAULT_PARSERS } from 'hyparquet/src/convert.js';
+import { prefetchPageIndexes } from 'hyparquet/src/plan.js';
 import { wkbToGeojson } from 'hyparquet/src/wkb.js';
 
 import {
@@ -18,6 +19,7 @@ import {
 } from './coalescing-buffer.js';
 import { selectLevelByGsd } from './level.js';
 import { type BboxCovering, type CogpMeta, extractCogpDocument, type GeoMeta } from './meta.js';
+import { rangeCachedAsyncBuffer, type RangeCacheOptions } from './range-cache.js';
 
 // Minimal structural view of the metadata object we need; this avoids tight
 // coupling to a specific hyparquet major version's exported types.
@@ -25,19 +27,35 @@ interface FullFileMetadata extends FileMetadataLike {
   key_value_metadata?: ReadonlyArray<{ key: string; value?: string | null }> | null;
 }
 
+type PageIndexPlan = Awaited<ReturnType<typeof prefetchPageIndexes>>;
+
 export type BboxInput = Bbox | readonly [number, number, number, number];
 
 export interface OpenOptions {
   fetch?: typeof fetch;
   byteLength?: number;
+  /** Additional HTTP options. Browser caching is always forced to `no-store`. */
+  requestInit?: Omit<RequestInit, 'cache'>;
   /** Coalesce nearby concurrent HTTP ranges; enabled by default. */
   rangeCoalescing?: RangeCoalescingOptions | false;
+  /** In-memory compressed range cache; enabled with a 64 MiB limit by default. */
+  rangeCache?: RangeCacheOptions | false;
 }
 
-// Cap on cumulative `num_rows` packed into a single coalesced fetch. A run
+// Cap on cumulative `num_rows` packed into a single decode batch. A batch
 // is read by one `parquetReadObjects` call that materializes every row in
-// the run as one array, so peak in-flight memory scales with this value.
-const RUN_MAX_ROWS = 50_000;
+// the batch as one array, so peak in-flight memory scales with this value.
+const DECODE_BATCH_MAX_ROWS = 50_000;
+
+// PageIndex planning is I/O-bound and much lighter than decoding. Looking
+// ahead across several RowGroups removes per-group round trips while keeping
+// speculative index reads bounded when maxRows stops a broad query early.
+const PAGE_INDEX_WINDOW_MAX_GROUPS = 16;
+
+// Bbox reads have already been narrowed to selected pages, so a small amount
+// of decode concurrency is safe and lets ranges from adjacent RowGroups share
+// an HTTP batch. Full-file reads remain serial to avoid multiplying memory use.
+const BBOX_DECODE_CONCURRENCY = 4;
 
 // Custom parsers handed to hyparquet so it returns raw WKB bytes for
 // GEOMETRY/GEOGRAPHY columns instead of eagerly building nested-array
@@ -73,7 +91,7 @@ export interface ReadOptions {
    * provided the value reflects rows actually returned to the caller, not
    * the pre-filter row-group size. The check fires per surviving row, so
    * the returned count never exceeds `maxRows`. Already-dispatched row
-   * group fetches (runs coalesced upstream) still complete, but later runs
+   * batch fetches already dispatched upstream still complete, but later batches
    * are skipped entirely.
    */
   maxRows?: number;
@@ -97,10 +115,14 @@ export class CogpReader {
     const fetchOpts: Record<string, unknown> = { url };
     if (opts.fetch) fetchOpts['fetch'] = opts.fetch;
     if (opts.byteLength !== undefined) fetchOpts['byteLength'] = opts.byteLength;
+    fetchOpts['requestInit'] = { ...opts.requestInit, cache: 'no-store' } satisfies RequestInit;
     const source = await asyncBufferFromUrl(fetchOpts as { url: string });
-    const file = opts.rangeCoalescing === false
+    const coalesced = opts.rangeCoalescing === false
       ? source
       : coalescingAsyncBuffer(source, opts.rangeCoalescing);
+    const file = opts.rangeCache === false
+      ? coalesced
+      : rangeCachedAsyncBuffer(coalesced, opts.rangeCache);
     return CogpReader.fromAsyncBuffer(file, url);
   }
 
@@ -249,7 +271,7 @@ export class CogpReader {
       return false;
     };
     let stopped = false;
-    for await (const batch of this.streamRuns(rgs, columns)) {
+    for await (const batch of this.streamBatches(rgs, columns, bbox)) {
       if (!paths) {
         for (const row of batch) {
           if (acceptRow(row)) {
@@ -304,51 +326,98 @@ export class CogpReader {
   }
 
   /**
-   * Materialize consecutive row-group runs in order. Each run is capped at
-   * `RUN_MAX_ROWS`, bounding peak memory while allowing hyparquet to combine
-   * adjacent column-chunk reads. Byte-range reuse is delegated to the HTTP
-   * cache instead of retaining decoded row objects in the JS heap.
+   * Plan PageIndexes in bounded I/O windows, then materialize consecutive
+   * RowGroups in separately bounded decode batches. Keeping those boundaries
+   * independent avoids turning the memory limit into an HTTP round-trip limit.
    */
-  private async *streamRuns(
+  private async *streamBatches(
     rgIndices: number[],
     columns: string[] | undefined,
+    bbox?: Bbox,
   ): AsyncGenerator<Record<string, unknown>[]> {
     if (rgIndices.length === 0) return;
 
-    for (const run of this.coalescedRuns(rgIndices)) {
-      const startRg = run[0]!;
-      const endRg = run[run.length - 1]!;
-      const rowStart = this.rowOffsets[startRg]!;
-      const rowEnd = rowStart + this.sumRowsInRange(startRg, endRg);
-      const readArgs: Record<string, unknown> = {
-        file: this.file,
-        metadata: this.metadata,
-        rowStart,
-        rowEnd,
-        compressors,
-        parsers: LAZY_GEO_PARSERS,
-      };
-      if (columns) readArgs['columns'] = columns;
-      yield (await parquetReadObjects(readArgs as never)) as Record<string, unknown>[];
+    // Keep the four spatial predicates together: hyparquet uses this one
+    // expression for PageIndex pruning and exact row filtering. PageIndexes
+    // are fetched lazily only for bbox reads and only for candidate row groups.
+    const filter = bbox ? bboxFilter(this.bboxPaths, bbox) : undefined;
+    const indexWindows: number[][] = [];
+    if (bbox) {
+      for (let i = 0; i < rgIndices.length; i += PAGE_INDEX_WINDOW_MAX_GROUPS) {
+        indexWindows.push(rgIndices.slice(i, i + PAGE_INDEX_WINDOW_MAX_GROUPS));
+      }
+    } else {
+      indexWindows.push(rgIndices);
+    }
+
+    for (const window of indexWindows) {
+      const pageIndexPlan = bbox
+        ? await this.prefetchPageIndexPlan(window, columns, bbox)
+        : undefined;
+      const batches = this.decodeBatches(window);
+      const concurrency = bbox ? BBOX_DECODE_CONCURRENCY : 1;
+      for (let i = 0; i < batches.length; i += concurrency) {
+        // Await a complete wave so every rejection is observed. This also
+        // prevents a fast batch from continuously running ahead of a slow one.
+        const wave = await Promise.all(
+          batches.slice(i, i + concurrency).map(batch =>
+            this.readBatch(batch, columns, filter, pageIndexPlan),
+          ),
+        );
+        for (const rows of wave) yield rows;
+      }
     }
   }
 
-  private coalescedRuns(indices: number[]): Array<number[]> {
-    const runs: Array<number[]> = [];
+  private async readBatch(
+    batch: number[],
+    columns: string[] | undefined,
+    filter: Record<string, unknown> | undefined,
+    pageIndexPlan: PageIndexPlan | undefined,
+  ): Promise<Record<string, unknown>[]> {
+    const startRg = batch[0]!;
+    const endRg = batch[batch.length - 1]!;
+    const rowStart = this.rowOffsets[startRg]!;
+    const rowEnd = rowStart + this.sumRowsInRange(startRg, endRg);
+    const readArgs: Record<string, unknown> = {
+      file: this.file,
+      metadata: this.metadata,
+      rowStart,
+      rowEnd,
+      filter,
+      usePageIndex: false,
+      compressors,
+      parsers: LAZY_GEO_PARSERS,
+    };
+    if (pageIndexPlan) {
+      readArgs['pageRangesByGroup'] = pageIndexPlan.pageRangesByGroup;
+      readArgs['pageLocationsByGroup'] = pageIndexPlan.pageLocationsByGroup;
+    }
+    if (columns) readArgs['columns'] = columns;
+    if (!filter) delete readArgs['filter'];
+    return parquetReadObjects(readArgs as never) as Promise<Record<string, unknown>[]>;
+  }
+
+  private decodeBatches(indices: number[]): Array<number[]> {
+    const batches: Array<number[]> = [];
     let i = 0;
     while (i < indices.length) {
-      const run: number[] = [indices[i]!];
+      const batch: number[] = [indices[i]!];
       let acc = Number(this.metadata.row_groups[indices[i]!]?.num_rows ?? 0);
       let j = i + 1;
-      while (j < indices.length && indices[j]! === indices[j - 1]! + 1 && acc < RUN_MAX_ROWS) {
-        run.push(indices[j]!);
+      while (
+        j < indices.length &&
+        indices[j]! === indices[j - 1]! + 1 &&
+        acc < DECODE_BATCH_MAX_ROWS
+      ) {
+        batch.push(indices[j]!);
         acc += Number(this.metadata.row_groups[indices[j]!]?.num_rows ?? 0);
         j++;
       }
-      runs.push(run);
+      batches.push(batch);
       i = j;
     }
-    return runs;
+    return batches;
   }
 
   private sumRowsInRange(start: number, end: number): number {
@@ -359,6 +428,38 @@ export class CogpReader {
     return n;
   }
 
+  private async prefetchPageIndexPlan(
+    rgIndices: number[],
+    columns: string[] | undefined,
+    bbox: Bbox,
+  ): Promise<PageIndexPlan> {
+    const firstRg = rgIndices[0]!;
+    const lastRg = rgIndices[rgIndices.length - 1]!;
+    const rowStart = this.rowOffsets[firstRg]!;
+    const rowEnd = this.rowOffsets[lastRg]! +
+      Number(this.metadata.row_groups[lastRg]?.num_rows ?? 0);
+    return prefetchPageIndexes({
+      file: this.file,
+      metadata: this.metadata,
+      filter: bboxFilter(this.bboxPaths, bbox),
+      rowStart,
+      rowEnd,
+      columns,
+      parsers: LAZY_GEO_PARSERS,
+    } as never);
+  }
+
+}
+
+function bboxFilter(paths: BboxCovering, bbox: Bbox): Record<string, unknown> {
+  return {
+    $and: [
+      { [paths.xmin.join('.')]: { $lte: bbox.maxX } },
+      { [paths.ymin.join('.')]: { $lte: bbox.maxY } },
+      { [paths.xmax.join('.')]: { $gte: bbox.minX } },
+      { [paths.ymax.join('.')]: { $gte: bbox.minY } },
+    ],
+  };
 }
 
 function normalizeBbox(input?: BboxInput): Bbox | undefined {

--- a/cogp-js/test/coalescing-buffer.test.mjs
+++ b/cogp-js/test/coalescing-buffer.test.mjs
@@ -20,7 +20,10 @@ function sourceFixture(size = 256) {
 
 test('coalesces nearby concurrent slices and returns exact bytes', async () => {
   const { source, calls } = sourceFixture();
-  const file = coalescingAsyncBuffer(source, { maxGapBytes: 8 });
+  const file = coalescingAsyncBuffer(source, {
+    maxGapBytes: 8,
+    maxExtraBytes: 8,
+  });
 
   const [a, b, c] = await Promise.all([
     file.slice(10, 20),
@@ -43,23 +46,40 @@ test('does not merge across the gap budget', async () => {
   assert.deepEqual(calls, [[0, 10], [19, 29], [40, 45]]);
 });
 
-test('limits cumulative extra transfer with maxOverfetchRatio', async () => {
+test('limits cumulative extra transfer with an absolute byte budget', async () => {
   const { source, calls } = sourceFixture();
   const file = coalescingAsyncBuffer(source, {
     maxGapBytes: 100,
-    maxOverfetchRatio: 1.25,
+    maxExtraBytes: 5,
   });
 
   await Promise.all([file.slice(0, 10), file.slice(15, 25), file.slice(31, 41)]);
 
-  // [0,10) + [15,25) is exactly 25 / 20 = 1.25 and may merge. Adding
-  // [31,41) would make the run 41 / 30 > 1.25, so it starts a new request.
+  // The first merge spends the five-byte budget. The next six-byte gap starts
+  // a new request even though it is within maxGapBytes by itself.
   assert.deepEqual(calls, [[0, 25], [31, 41]]);
+});
+
+test('limits the size of a merged request', async () => {
+  const { source, calls } = sourceFixture();
+  const file = coalescingAsyncBuffer(source, {
+    maxGapBytes: 8,
+    maxExtraBytes: 100,
+    maxRequestBytes: 20,
+  });
+
+  await Promise.all([file.slice(0, 10), file.slice(15, 25)]);
+
+  assert.deepEqual(calls, [[0, 10], [15, 25]]);
 });
 
 test('always merges overlapping slices', async () => {
   const { source, calls } = sourceFixture();
-  const file = coalescingAsyncBuffer(source, { maxGapBytes: 0 });
+  const file = coalescingAsyncBuffer(source, {
+    maxGapBytes: 0,
+    maxExtraBytes: 0,
+    maxRequestBytes: 1,
+  });
 
   const [a, b] = await Promise.all([file.slice(10, 30), file.slice(20, 40)]);
 
@@ -77,4 +97,11 @@ test('supports an omitted end and rejects invalid bounds', async () => {
   assert.deepEqual([...new Uint8Array(tail)], [28, 29, 30, 31]);
   await assert.rejects(file.slice(-1, 2), /outside buffer/);
   await assert.rejects(file.slice(0, 33), /outside buffer/);
+});
+
+test('rejects invalid coalescing budgets', () => {
+  const { source } = sourceFixture();
+  assert.throws(() => coalescingAsyncBuffer(source, { maxGapBytes: -1 }), /maxGapBytes/);
+  assert.throws(() => coalescingAsyncBuffer(source, { maxExtraBytes: -1 }), /maxExtraBytes/);
+  assert.throws(() => coalescingAsyncBuffer(source, { maxRequestBytes: 0 }), /maxRequestBytes/);
 });

--- a/cogp-js/test/range-cache.test.mjs
+++ b/cogp-js/test/range-cache.test.mjs
@@ -1,0 +1,98 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { rangeCachedAsyncBuffer } from '../dist/range-cache.js';
+
+function sourceFixture(size = 256) {
+  const bytes = Uint8Array.from({ length: size }, (_, i) => i & 0xff);
+  const calls = [];
+  return {
+    calls,
+    bytes,
+    source: {
+      byteLength: size,
+      slice(start, end = size) {
+        calls.push([start, end]);
+        return bytes.slice(start, end).buffer;
+      },
+    },
+  };
+}
+
+test('serves contained slices from one cached range', async () => {
+  const { source, calls } = sourceFixture();
+  const file = rangeCachedAsyncBuffer(source, { maxBytes: 64 });
+
+  const outer = await file.slice(10, 30);
+  new Uint8Array(outer)[0] = 255;
+  const inner = await file.slice(12, 16);
+
+  assert.deepEqual(calls, [[10, 30]]);
+  assert.deepEqual([...new Uint8Array(inner)], [12, 13, 14, 15]);
+});
+
+test('shares an in-flight containing request', async () => {
+  const { bytes } = sourceFixture();
+  const calls = [];
+  let complete;
+  const source = {
+    byteLength: bytes.byteLength,
+    slice(start, end) {
+      calls.push([start, end]);
+      return new Promise(resolve => {
+        complete = () => resolve(bytes.slice(start, end).buffer);
+      });
+    },
+  };
+  const file = rangeCachedAsyncBuffer(source);
+
+  const outer = file.slice(10, 30);
+  const inner = file.slice(12, 16);
+  assert.deepEqual(calls, [[10, 30]]);
+  complete();
+
+  assert.equal((await outer).byteLength, 20);
+  assert.deepEqual([...new Uint8Array(await inner)], [12, 13, 14, 15]);
+});
+
+test('evicts the least recently used settled range', async () => {
+  const { source, calls } = sourceFixture();
+  const file = rangeCachedAsyncBuffer(source, { maxBytes: 20 });
+
+  await file.slice(0, 10);
+  await file.slice(10, 20);
+  await file.slice(0, 5); // Touch the first entry.
+  await file.slice(20, 30); // Evict [10, 20).
+  await file.slice(10, 20);
+
+  assert.deepEqual(calls, [[0, 10], [10, 20], [20, 30], [10, 20]]);
+});
+
+test('does not retain failed or oversized reads', async () => {
+  const { bytes } = sourceFixture();
+  let calls = 0;
+  const source = {
+    byteLength: bytes.byteLength,
+    slice(start, end) {
+      calls++;
+      if (calls === 1) return Promise.reject(new Error('temporary failure'));
+      return bytes.slice(start, end).buffer;
+    },
+  };
+  const file = rangeCachedAsyncBuffer(source, { maxBytes: 8 });
+
+  await assert.rejects(file.slice(0, 4), /temporary failure/);
+  await file.slice(0, 4);
+  await file.slice(20, 30);
+  await file.slice(20, 30);
+
+  assert.equal(calls, 4);
+});
+
+test('validates the cache budget and slice bounds', async () => {
+  const { source } = sourceFixture();
+  assert.throws(() => rangeCachedAsyncBuffer(source, { maxBytes: -1 }), /maxBytes/);
+  const file = rangeCachedAsyncBuffer(source);
+  await assert.rejects(file.slice(-1, 2), /outside buffer/);
+  await assert.rejects(file.slice(0, 257), /outside buffer/);
+});

--- a/cogp-js/test/reader-open.test.mjs
+++ b/cogp-js/test/reader-open.test.mjs
@@ -1,0 +1,37 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { CogpReader } from '../dist/index.js';
+
+test('open disables the browser cache for HEAD and range requests', async () => {
+  const receivedInits = [];
+  const invalidEmptyParquet = Uint8Array.of(0, 0, 0, 0, 80, 65, 82, 49);
+  const fetch = async (_input, init) => {
+    receivedInits.push(init);
+    if (init?.method === 'HEAD') {
+      return new Response(null, {
+        status: 200,
+        headers: { 'Content-Length': String(invalidEmptyParquet.byteLength) },
+      });
+    }
+    return new Response(invalidEmptyParquet, { status: 206 });
+  };
+
+  await assert.rejects(CogpReader.open('https://example.test/data.parquet', {
+    fetch,
+    // Runtime callers cannot override the cache mode even from plain JS.
+    requestInit: {
+      cache: 'force-cache',
+      credentials: 'include',
+      headers: { 'X-Test': 'preserved' },
+    },
+  }));
+
+  assert.equal(receivedInits.length, 2);
+  assert.ok(receivedInits.every(init => init.cache === 'no-store'));
+  assert.ok(receivedInits.every(init => init.credentials === 'include'));
+  assert.equal(receivedInits[0].method, 'HEAD');
+  const headers = new Headers(receivedInits[1].headers);
+  assert.equal(headers.get('X-Test'), 'preserved');
+  assert.equal(headers.get('Range'), 'bytes=0-7');
+});

--- a/cogp-rs/Cargo.toml
+++ b/cogp-rs/Cargo.toml
@@ -23,6 +23,7 @@ arrow-schema = "56"
 parquet = { version = "56", default-features = false, features = ["arrow", "snap", "zstd", "brotli", "lz4"] }
 byteorder = "1"
 rayon = "1"
+thrift = { version = "0.17", default-features = false }
 
 [features]
 default = []

--- a/cogp-rs/Cargo.toml
+++ b/cogp-rs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cogp"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 description = "Reference CLI for the Cloud Optimized GeoParquet Profile (COGP)"
 license = "MIT"

--- a/cogp-rs/README.md
+++ b/cogp-rs/README.md
@@ -77,8 +77,16 @@ readable by any renderer regardless of which path you pick.
 
 Other options:
 
-- `--row-group-size` (default `10000`) — max Parquet row group size in rows.
+- `--row-group-size` (default `65536`) — max Parquet row group size in rows.
+- `--page-row-count` — enables PageIndex layout with at most this many
+  top-level rows per data page. The converter spatially packs page intervals
+  within each row group and writes Page-level statistics for the four `bbox`
+  leaves. If omitted, the legacy row-group-only layout is retained.
   Row group boundaries always align with level boundaries.
+- `--dictionary-page-size-limit` — best-effort byte limit for dictionary pages.
+  Smaller limits bound the compulsory dictionary read when a sparse PageIndex
+  query projects a high-cardinality column. Low-cardinality dictionaries remain
+  smaller than the limit naturally. If omitted, Parquet's 1 MiB default is used.
 - `--row-group-max-bytes` — max estimated encoded Parquet row group size in
   bytes. This must be a numeric byte count, without suffixes. It is enforced
   using the Parquet writer's in-progress encoded-size estimate, checked at batch
@@ -172,10 +180,14 @@ let by_bbox = reader.row_groups_intersecting_bbox([139.0, 35.0, 140.0, 36.0]);
 let by_level = reader.row_groups_up_to_level(8);
 let rgs: Vec<usize> = by_bbox.into_iter().filter(|i| by_level.contains(i)).collect();
 
-// Per request: discard row groups whose bbox misses the query.
-// Test each returned feature bbox for an exact filter.
+// Per request: prune Row Groups, then lazily read bbox PageIndexes and skip
+// non-intersecting Pages. Test each returned feature bbox for an exact filter.
 let file = File::open("data.cogp.parquet")?;
-let batches = reader.sync_batch_reader(file, &rgs)?;
+let batches = reader.sync_batch_reader_with_bbox(
+    file,
+    &rgs,
+    [139.0, 35.0, 140.0, 36.0],
+)?;
 
 for batch in batches {
     let batch = batch?;
@@ -237,10 +249,17 @@ let rgs: Vec<usize> = {
 let per_request_reader = RangeCoalescingReader::try_new(
     ParquetObjectReader::new(store.clone(), path.clone()).with_file_size(head.size),
     RangeCoalescingOptions::default()
-        .with_max_gap_bytes(128 * 1024)
-        .with_max_overfetch_ratio(1.25),
+        .with_max_gap_bytes(16 * 1024)
+        .with_max_extra_bytes(64 * 1024)
+        .with_max_request_bytes(2 * 1024 * 1024),
 )?;
-let mut stream = reader.async_batch_stream(per_request_reader, &rgs)?;
+let mut stream = reader
+    .async_batch_stream_with_bbox(
+        per_request_reader,
+        &rgs,
+        [139.0, 35.0, 140.0, 36.0],
+    )
+    .await?;
 
 while let Some(batch) = stream.next().await {
     let _batch = batch?;
@@ -264,10 +283,11 @@ Construction (parses and caches the footer):
 Remote range coalescing (`feature = "async"):
 
 - `RangeCoalescingReader::new(reader)` — wrap a cloneable `AsyncFileReader`
-  using the defaults: a 128 KiB maximum gap and 1.25 maximum overfetch ratio.
+  using the defaults: a 32 KiB maximum gap, 128 KiB cumulative extra bytes,
+  and a 2 MiB maximum merged request.
 - `RangeCoalescingReader::try_new(reader, options)` — configure
-  `max_gap_bytes` and `max_overfetch_ratio`. Both constraints must permit a
-  merge; overlapping ranges always merge. This adapter bypasses
+  `max_gap_bytes`, `max_extra_bytes`, and `max_request_bytes`. All constraints
+  must permit a merge; overlapping ranges always merge. This adapter bypasses
   `object_store`'s fixed one-megabyte `get_ranges` coalescing policy.
 
 Selectors (`&self`, no IO — they only consult the cached footer):
@@ -283,8 +303,16 @@ Selectors (`&self`, no IO — they only consult the cached footer):
 Per-request reads (hand in a fresh sync / async reader; footer is reused):
 
 - `sync_batch_reader(reader, &row_groups)` — `ParquetRecordBatchReader`.
+- `sync_batch_reader_with_bbox(reader, &row_groups, bbox)` — lazily fetches
+  bbox PageIndexes and applies a conservative Page-level `RowSelection`.
 - `async_batch_stream(reader, &row_groups)` — `ParquetRecordBatchStream`
   (`feature = "async"`).
+- `async_batch_stream_with_bbox(reader, &row_groups, bbox)` — asynchronous
+  PageIndex pruning (`feature = "async"`).
+
+The bbox methods fall back to complete candidate Row Groups when PageIndexes
+are absent. Page pruning is conservative; callers must still perform exact
+per-feature bbox intersection checks.
 
 ## validate
 

--- a/cogp-rs/src/convert.rs
+++ b/cogp-rs/src/convert.rs
@@ -53,9 +53,20 @@ pub struct ConvertArgs {
     /// when --gsd is omitted. Same Web Mercator assumption as --webmerc-minzoom.
     #[arg(long, default_value_t = 16)]
     pub webmerc_maxzoom: u32,
-    /// Parquet row group size in rows.
-    #[arg(long, default_value_t = 10000)]
+    /// Maximum Parquet row group size in rows.
+    #[arg(long, default_value_t = 65_536)]
     pub row_group_size: usize,
+    /// Maximum top-level rows per Parquet data page. When set, the converter
+    /// writes PageIndexes for the bbox leaves and spatially packs each page
+    /// within its row group. Omit it to retain the legacy row-group-only layout.
+    #[arg(long)]
+    pub page_row_count: Option<usize>,
+    /// Best-effort maximum dictionary page size in bytes for dictionary-encoded
+    /// columns. Smaller values bound the compulsory dictionary read for sparse
+    /// PageIndex queries; low-cardinality dictionaries naturally remain smaller.
+    /// Omit this option to retain Parquet's 1 MiB default.
+    #[arg(long)]
+    pub dictionary_page_size_limit: Option<usize>,
     /// Maximum estimated encoded Parquet row group size in bytes
     #[arg(long)]
     pub row_group_max_bytes: Option<usize>,
@@ -315,6 +326,12 @@ pub fn run(args: ConvertArgs) -> Result<()> {
     if args.row_group_size == 0 {
         bail!("--row-group-size must be >= 1");
     }
+    if args.page_row_count == Some(0) {
+        bail!("--page-row-count must be >= 1");
+    }
+    if args.dictionary_page_size_limit == Some(0) {
+        bail!("--dictionary-page-size-limit must be >= 1");
+    }
     eprintln!("[1/4] Reading input metadata: {}", args.input.display());
     let file =
         File::open(&args.input).with_context(|| format!("opening {}", args.input.display()))?;
@@ -463,6 +480,15 @@ pub fn run(args: ConvertArgs) -> Result<()> {
 
     for (level_idx, rows) in per_level.iter_mut().enumerate() {
         str_pack(rows, &bboxes, args.row_group_size, level_idx);
+        if let Some(page_row_count) = args.page_row_count {
+            str_pack_pages(
+                rows,
+                &bboxes,
+                args.row_group_size,
+                page_row_count,
+                level_idx,
+            );
+        }
     }
 
     eprintln!("[4/4] Writing COGP file: {}", args.output.display());
@@ -473,18 +499,29 @@ pub fn run(args: ConvertArgs) -> Result<()> {
         .collect();
     let mut output_fields: Vec<Arc<Field>> = Vec::new();
     let mut keep_col_indices: Vec<usize> = Vec::new();
+    let mut bbox_output_idx: Option<usize> = None;
     for (i, f) in input_schema.fields().iter().enumerate() {
         if drop_names.contains(&f.name().as_str()) {
             eprintln!(
                 "      note: dropping input column `{}` (will be overwritten)",
                 f.name()
             );
+            // Reinsert the canonical bbox at the first replaced column so an
+            // existing conforming schema keeps its top-level field order.
+            if bbox_output_idx.is_none() {
+                bbox_output_idx = Some(output_fields.len());
+                output_fields.push(Arc::new(bbox_struct_field()));
+            }
             continue;
         }
         output_fields.push(f.clone());
         keep_col_indices.push(i);
     }
-    output_fields.push(Arc::new(bbox_struct_field()));
+    let bbox_output_idx = bbox_output_idx.unwrap_or_else(|| {
+        let idx = output_fields.len();
+        output_fields.push(Arc::new(bbox_struct_field()));
+        idx
+    });
     let output_schema = Arc::new(Schema::new(output_fields));
 
     let dataset_bbox = bboxes
@@ -504,11 +541,27 @@ pub fn run(args: ConvertArgs) -> Result<()> {
         .set_compression(Compression::ZSTD(ZstdLevel::try_new(3)?))
         .set_max_row_group_size(args.row_group_size)
         .set_statistics_enabled(EnabledStatistics::Chunk)
-        .set_offset_index_disabled(true)
         .set_column_dictionary_enabled(ColumnPath::from(geom_col_name.as_str()), false);
+    if let Some(dictionary_page_size_limit) = args.dictionary_page_size_limit {
+        props_builder = props_builder.set_dictionary_page_size_limit(dictionary_page_size_limit);
+    }
     for child in ["xmin", "ymin", "xmax", "ymax"] {
         let path = ColumnPath::from(vec!["bbox".to_string(), child.to_string()]);
-        props_builder = props_builder.set_column_dictionary_enabled(path, false);
+        props_builder = props_builder.set_column_dictionary_enabled(path.clone(), false);
+        if args.page_row_count.is_some() {
+            props_builder =
+                props_builder.set_column_statistics_enabled(path, EnabledStatistics::Page);
+        }
+    }
+    if let Some(page_row_count) = args.page_row_count {
+        // Matching the write batch to the row limit lets the writer honor the
+        // boundary closely even for narrow columns. Offset indexes remain on
+        // for every leaf so a bbox PageIndex selection maps to projected data.
+        props_builder = props_builder
+            .set_data_page_row_count_limit(page_row_count)
+            .set_write_batch_size(page_row_count);
+    } else {
+        props_builder = props_builder.set_offset_index_disabled(true);
     }
     let props = props_builder.build();
     let out_file = File::create(&args.output)
@@ -529,6 +582,7 @@ pub fn run(args: ConvertArgs) -> Result<()> {
     let producer_meta = arrow_meta.clone();
     let producer_input = args.input.clone();
     let producer_keep = keep_col_indices;
+    let producer_bbox_output_idx = bbox_output_idx;
     let producer_per_level = per_level;
     let producer_row_group_size = args.row_group_size;
     let producer = thread::spawn(move || -> Result<()> {
@@ -551,6 +605,7 @@ pub fn run(args: ConvertArgs) -> Result<()> {
                         chunk,
                         &producer_bboxes,
                         &producer_schema,
+                        producer_bbox_output_idx,
                     )?;
                     Ok((*level_i, batches))
                 })
@@ -1057,6 +1112,7 @@ fn gather_chunk(
     chunk: &[u32],
     bboxes: &[Bbox],
     output_schema: &Arc<Schema>,
+    bbox_output_idx: usize,
 ) -> Result<Vec<RecordBatch>> {
     let mut sorted = chunk.to_vec();
     sorted.sort_unstable();
@@ -1123,15 +1179,22 @@ fn gather_chunk(
             seg_bytes += weights[seg_end];
             seg_end += 1;
         }
-        let mut cols: Vec<ArrayRef> = Vec::with_capacity(n_cols + 1);
-        for refs in &col_refs {
-            cols.push(interleave(refs, &locs[seg_start..seg_end])?);
-        }
         let seg_bboxes: Vec<Bbox> = chunk[seg_start..seg_end]
             .iter()
             .map(|r| bboxes[*r as usize])
             .collect();
-        cols.push(Arc::new(build_bbox_struct(&seg_bboxes)?));
+        let bbox: ArrayRef = Arc::new(build_bbox_struct(&seg_bboxes)?);
+        let mut cols: Vec<ArrayRef> = Vec::with_capacity(n_cols + 1);
+        let mut kept = col_refs.iter();
+        for output_idx in 0..=n_cols {
+            if output_idx == bbox_output_idx {
+                cols.push(bbox.clone());
+            } else {
+                let refs = kept.next().expect("output layout missing input column");
+                cols.push(interleave(refs, &locs[seg_start..seg_end])?);
+            }
+        }
+        debug_assert!(kept.next().is_none());
         out.push(RecordBatch::try_new(output_schema.clone(), cols)?);
         seg_start = seg_end;
     }
@@ -1450,6 +1513,25 @@ fn str_pack(rows: &mut Vec<u32>, bboxes: &[Bbox], row_group_size: usize, level_i
         row_group_size,
         dir,
     );
+}
+
+/// Preserve row-group membership while recursively packing each row group's
+/// page-sized intervals. Page indexes describe row intervals, so locality must
+/// hold at this nested physical unit rather than only at the row-group level.
+fn str_pack_pages(
+    rows: &mut [u32],
+    bboxes: &[Bbox],
+    row_group_size: usize,
+    page_row_count: usize,
+    level_idx: usize,
+) {
+    rows.chunks_mut(row_group_size)
+        .enumerate()
+        .for_each(|(row_group_idx, row_group)| {
+            let mut scratch = vec![(0.0, 0); row_group.len()];
+            let dir = SnakeStart::for_level(level_idx + row_group_idx).initial_dir();
+            str_pack_rec(row_group, &mut scratch, bboxes, page_row_count, dir);
+        });
 }
 
 fn str_pack_rec(

--- a/cogp-rs/src/lib.rs
+++ b/cogp-rs/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod convert;
 pub mod meta;
+mod page_index;
 #[cfg(feature = "async")]
 mod range_coalescing;
 pub mod reader;

--- a/cogp-rs/src/meta.rs
+++ b/cogp-rs/src/meta.rs
@@ -3,7 +3,7 @@ use std::collections::BTreeMap;
 
 pub const COGP_METADATA_KEY: &str = "cogp";
 pub const GEO_METADATA_KEY: &str = "geo";
-pub const COGP_VERSION: &str = "0.1.0";
+pub const COGP_VERSION: &str = "0.1.1";
 pub const GEOPARQUET_VERSION: &str = "1.1.0";
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/cogp-rs/src/page_index.rs
+++ b/cogp-rs/src/page_index.rs
@@ -1,0 +1,241 @@
+//! Lazy bbox PageIndex loading and conservative row selection.
+//!
+//! The Parquet footer already carries every ColumnIndex/OffsetIndex byte range.
+//! Loading all indexes when a [`crate::reader::Reader`] opens would make startup
+//! proportional to the entire dataset. This module instead fetches only the
+//! four bbox indexes for Row Groups that survived footer-level pruning.
+
+use anyhow::{bail, Context, Result};
+use parquet::arrow::arrow_reader::RowSelection;
+#[cfg(feature = "async")]
+use parquet::arrow::async_reader::AsyncFileReader;
+use parquet::file::metadata::ParquetMetaData;
+use parquet::file::reader::ChunkReader;
+use parquet::format::{ColumnIndex, OffsetIndex};
+use parquet::thrift::TSerializable;
+use std::io::Cursor;
+use std::ops::Range;
+use thrift::protocol::TCompactInputProtocol;
+
+#[derive(Clone, Copy)]
+enum BboxLeaf {
+    Xmin,
+    Ymin,
+    Xmax,
+    Ymax,
+}
+
+impl BboxLeaf {
+    fn misses(self, min: f64, max: f64, query: [f64; 4]) -> bool {
+        let [qxmin, qymin, qxmax, qymax] = query;
+        match self {
+            Self::Xmin => min > qxmax,
+            Self::Ymin => min > qymax,
+            Self::Xmax => max < qxmin,
+            Self::Ymax => max < qymin,
+        }
+    }
+}
+
+struct Request {
+    output_row_start: usize,
+    row_group_rows: usize,
+    leaf: BboxLeaf,
+    column_index: Range<u64>,
+    offset_index: Range<u64>,
+}
+
+struct Plan {
+    total_rows: usize,
+    requests: Vec<Request>,
+}
+
+impl Plan {
+    fn new(metadata: &ParquetMetaData, row_groups: &[usize], bbox_columns: [usize; 4]) -> Self {
+        let mut output_row_start = 0;
+        let mut requests = Vec::new();
+        for &row_group_index in row_groups {
+            let Some(row_group) = metadata.row_groups().get(row_group_index) else {
+                continue;
+            };
+            let row_group_rows = row_group.num_rows() as usize;
+            for (leaf, column_index) in [
+                BboxLeaf::Xmin,
+                BboxLeaf::Ymin,
+                BboxLeaf::Xmax,
+                BboxLeaf::Ymax,
+            ]
+            .into_iter()
+            .zip(bbox_columns)
+            {
+                let Some(column) = row_group.columns().get(column_index) else {
+                    continue;
+                };
+                let (Some(column_index), Some(offset_index)) = (
+                    index_range(column.column_index_offset(), column.column_index_length()),
+                    index_range(column.offset_index_offset(), column.offset_index_length()),
+                ) else {
+                    continue;
+                };
+                requests.push(Request {
+                    output_row_start,
+                    row_group_rows,
+                    leaf,
+                    column_index,
+                    offset_index,
+                });
+            }
+            output_row_start += row_group_rows;
+        }
+        Self {
+            total_rows: output_row_start,
+            requests,
+        }
+    }
+
+    fn ranges(&self) -> Vec<Range<u64>> {
+        self.requests
+            .iter()
+            .flat_map(|request| [request.column_index.clone(), request.offset_index.clone()])
+            .collect()
+    }
+
+    fn selection<I, B>(self, buffers: I, query: [f64; 4]) -> Result<Option<RowSelection>>
+    where
+        I: IntoIterator<Item = B>,
+        B: AsRef<[u8]>,
+    {
+        if self.requests.is_empty() {
+            return Ok(None);
+        }
+        let mut buffers = buffers.into_iter();
+        let mut keep = vec![true; self.total_rows];
+        for request in self.requests {
+            let column_bytes = buffers.next().context("missing ColumnIndex response")?;
+            let offset_bytes = buffers.next().context("missing OffsetIndex response")?;
+            let column: ColumnIndex =
+                decode_thrift(column_bytes.as_ref()).context("decoding bbox ColumnIndex")?;
+            let offset: OffsetIndex =
+                decode_thrift(offset_bytes.as_ref()).context("decoding bbox OffsetIndex")?;
+            prune_pages(&mut keep, &request, &column, &offset, query);
+        }
+        if buffers.next().is_some() {
+            bail!("received more PageIndex responses than requested");
+        }
+        Ok(Some(selection_from_bitmap(&keep)))
+    }
+}
+
+pub(crate) fn read_sync<R: ChunkReader>(
+    reader: &R,
+    metadata: &ParquetMetaData,
+    row_groups: &[usize],
+    bbox_columns: [usize; 4],
+    query: [f64; 4],
+) -> Result<Option<RowSelection>> {
+    let plan = Plan::new(metadata, row_groups, bbox_columns);
+    let buffers = plan
+        .ranges()
+        .into_iter()
+        .map(|range| {
+            let len = usize::try_from(range.end - range.start)?;
+            Ok(reader.get_bytes(range.start, len)?)
+        })
+        .collect::<Result<Vec<_>>>()?;
+    plan.selection(buffers, query)
+}
+
+#[cfg(feature = "async")]
+pub(crate) async fn read_async<R: AsyncFileReader + Send>(
+    reader: &mut R,
+    metadata: &ParquetMetaData,
+    row_groups: &[usize],
+    bbox_columns: [usize; 4],
+    query: [f64; 4],
+) -> Result<Option<RowSelection>> {
+    let plan = Plan::new(metadata, row_groups, bbox_columns);
+    let ranges = plan.ranges();
+    if ranges.is_empty() {
+        return Ok(None);
+    }
+    let buffers = reader.get_byte_ranges(ranges).await?;
+    plan.selection(buffers, query)
+}
+
+fn index_range(offset: Option<i64>, length: Option<i32>) -> Option<Range<u64>> {
+    let start = u64::try_from(offset?).ok()?;
+    let length = u64::try_from(length?).ok()?;
+    start.checked_add(length).map(|end| start..end)
+}
+
+fn decode_thrift<T: TSerializable>(bytes: &[u8]) -> Result<T> {
+    let mut protocol = TCompactInputProtocol::new(Cursor::new(bytes));
+    Ok(T::read_from_in_protocol(&mut protocol)?)
+}
+
+fn prune_pages(
+    keep: &mut [bool],
+    request: &Request,
+    column: &ColumnIndex,
+    offset: &OffsetIndex,
+    query: [f64; 4],
+) {
+    let page_count = column
+        .min_values
+        .len()
+        .min(column.max_values.len())
+        .min(column.null_pages.len())
+        .min(offset.page_locations.len());
+    for page_index in 0..page_count {
+        if column.null_pages[page_index] {
+            continue;
+        }
+        let (Some(min), Some(max)) = (
+            parquet_f64(&column.min_values[page_index]),
+            parquet_f64(&column.max_values[page_index]),
+        ) else {
+            continue;
+        };
+        if !request.leaf.misses(min, max, query) {
+            continue;
+        }
+        let Ok(start) = usize::try_from(offset.page_locations[page_index].first_row_index) else {
+            continue;
+        };
+        let end = offset
+            .page_locations
+            .get(page_index + 1)
+            .and_then(|page| usize::try_from(page.first_row_index).ok())
+            .unwrap_or(request.row_group_rows)
+            .min(request.row_group_rows);
+        if start >= end || start >= request.row_group_rows {
+            continue;
+        }
+        let start = request.output_row_start + start;
+        let end = request.output_row_start + end;
+        keep[start..end].fill(false);
+    }
+}
+
+fn parquet_f64(bytes: &[u8]) -> Option<f64> {
+    Some(f64::from_le_bytes(bytes.try_into().ok()?))
+}
+
+fn selection_from_bitmap(keep: &[bool]) -> RowSelection {
+    let mut ranges = Vec::new();
+    let mut start = None;
+    for (row, &selected) in keep.iter().enumerate() {
+        match (start, selected) {
+            (None, true) => start = Some(row),
+            (Some(first), false) => {
+                ranges.push(first..row);
+                start = None;
+            }
+            _ => {}
+        }
+    }
+    if let Some(first) = start {
+        ranges.push(first..keep.len());
+    }
+    RowSelection::from_consecutive_ranges(ranges.into_iter(), keep.len())
+}

--- a/cogp-rs/src/range_coalescing.rs
+++ b/cogp-rs/src/range_coalescing.rs
@@ -2,7 +2,7 @@
 //!
 //! `object_store` coalesces vectored reads with a fixed one-megabyte gap. This
 //! adapter deliberately calls the wrapped reader's single-range operation so
-//! that its two explicit budgets are the only coalescing policy applied.
+//! that its three explicit byte budgets are the only coalescing policy applied.
 
 use anyhow::{bail, Result};
 use bytes::Bytes;
@@ -15,25 +15,29 @@ use parquet::file::metadata::ParquetMetaData;
 use std::ops::Range;
 use std::sync::Arc;
 
-const DEFAULT_MAX_GAP_BYTES: u64 = 128 * 1024;
-const DEFAULT_MAX_OVERFETCH_RATIO: f64 = 1.25;
+const DEFAULT_MAX_GAP_BYTES: u64 = 32 * 1024;
+const DEFAULT_MAX_EXTRA_BYTES: u64 = 128 * 1024;
+const DEFAULT_MAX_REQUEST_BYTES: u64 = 2 * 1024 * 1024;
 const MAX_PARALLEL_REQUESTS: usize = 10;
 
 /// Controls when adjacent byte ranges are fetched as one request.
 ///
-/// A merge must satisfy both limits. Overlapping ranges are always combined
-/// because doing so introduces no extra transfer.
-#[derive(Clone, Copy, Debug, PartialEq)]
+/// A merge must satisfy the maximum single gap, cumulative extra bytes, and
+/// merged request size. Overlapping ranges are always combined because doing
+/// so introduces no extra transfer.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct RangeCoalescingOptions {
     max_gap_bytes: u64,
-    max_overfetch_ratio: f64,
+    max_extra_bytes: u64,
+    max_request_bytes: u64,
 }
 
 impl Default for RangeCoalescingOptions {
     fn default() -> Self {
         Self {
             max_gap_bytes: DEFAULT_MAX_GAP_BYTES,
-            max_overfetch_ratio: DEFAULT_MAX_OVERFETCH_RATIO,
+            max_extra_bytes: DEFAULT_MAX_EXTRA_BYTES,
+            max_request_bytes: DEFAULT_MAX_REQUEST_BYTES,
         }
     }
 }
@@ -44,8 +48,13 @@ impl RangeCoalescingOptions {
         self
     }
 
-    pub fn with_max_overfetch_ratio(mut self, ratio: f64) -> Self {
-        self.max_overfetch_ratio = ratio;
+    pub fn with_max_extra_bytes(mut self, bytes: u64) -> Self {
+        self.max_extra_bytes = bytes;
+        self
+    }
+
+    pub fn with_max_request_bytes(mut self, bytes: u64) -> Self {
+        self.max_request_bytes = bytes;
         self
     }
 
@@ -53,16 +62,17 @@ impl RangeCoalescingOptions {
         self.max_gap_bytes
     }
 
-    pub fn max_overfetch_ratio(&self) -> f64 {
-        self.max_overfetch_ratio
+    pub fn max_extra_bytes(&self) -> u64 {
+        self.max_extra_bytes
+    }
+
+    pub fn max_request_bytes(&self) -> u64 {
+        self.max_request_bytes
     }
 
     fn validate(&self) -> Result<()> {
-        if !self.max_overfetch_ratio.is_finite() || self.max_overfetch_ratio < 1.0 {
-            bail!(
-                "max_overfetch_ratio must be a finite number >= 1, got {}",
-                self.max_overfetch_ratio
-            );
+        if self.max_request_bytes == 0 {
+            bail!("max_request_bytes must be positive");
         }
         Ok(())
     }
@@ -153,7 +163,7 @@ where
 #[derive(Debug)]
 struct Run {
     range: Range<u64>,
-    requested_bytes: u64,
+    extra_bytes: u64,
 }
 
 fn make_merged_ranges(
@@ -170,29 +180,32 @@ fn make_merged_ranges(
     let mut runs: Vec<Run> = Vec::new();
     for range in sorted {
         let Some(run) = runs.last_mut() else {
-            let requested_bytes = range.end - range.start;
             runs.push(Run {
                 range,
-                requested_bytes,
+                extra_bytes: 0,
             });
             continue;
         };
 
         let gap = range.start.saturating_sub(run.range.end);
         let merged_end = run.range.end.max(range.end);
-        let added_requested = range.end.saturating_sub(range.start.max(run.range.end));
-        let requested_bytes = run.requested_bytes + added_requested;
         let merged_span = merged_end - run.range.start;
-        let ratio = merged_span as f64 / requested_bytes as f64;
         let overlaps = range.start <= run.range.end;
+        let merged_extra = run.extra_bytes.checked_add(gap);
 
-        if overlaps || (gap <= options.max_gap_bytes && ratio <= options.max_overfetch_ratio) {
+        if overlaps
+            || (gap <= options.max_gap_bytes
+                && merged_extra.is_some_and(|extra| extra <= options.max_extra_bytes)
+                && merged_span <= options.max_request_bytes)
+        {
             run.range.end = merged_end;
-            run.requested_bytes = requested_bytes;
+            if let Some(extra) = merged_extra {
+                run.extra_bytes = extra;
+            }
         } else {
             runs.push(Run {
-                requested_bytes: range.end - range.start,
                 range,
+                extra_bytes: 0,
             });
         }
     }
@@ -235,18 +248,28 @@ fn slice_merged_range(
 mod tests {
     use super::*;
 
-    fn options(gap: u64, ratio: f64) -> RangeCoalescingOptions {
+    fn options(gap: u64, extra: u64, request: u64) -> RangeCoalescingOptions {
         RangeCoalescingOptions::default()
             .with_max_gap_bytes(gap)
-            .with_max_overfetch_ratio(ratio)
+            .with_max_extra_bytes(extra)
+            .with_max_request_bytes(request)
     }
 
     #[test]
-    fn merges_only_within_both_budgets() {
+    fn merges_only_within_all_budgets() {
         let ranges = vec![0..10, 15..25, 31..41, 200..210];
         assert_eq!(
-            make_merged_ranges(&ranges, options(100, 1.25)).unwrap(),
+            make_merged_ranges(&ranges, options(100, 5, 100)).unwrap(),
             vec![0..25, 31..41, 200..210]
+        );
+    }
+
+    #[test]
+    fn caps_merged_request_size() {
+        let ranges = vec![0..10, 15..25];
+        assert_eq!(
+            make_merged_ranges(&ranges, options(8, 100, 20)).unwrap(),
+            ranges
         );
     }
 
@@ -254,16 +277,16 @@ mod tests {
     fn overlapping_ranges_always_merge() {
         let ranges = vec![20..40, 10..30, 25..26];
         assert_eq!(
-            make_merged_ranges(&ranges, options(0, 1.0)).unwrap(),
+            make_merged_ranges(&ranges, options(0, 0, 1)).unwrap(),
             vec![10..40]
         );
     }
 
     #[test]
-    fn rejects_invalid_ratio() {
+    fn rejects_zero_max_request_bytes() {
         assert!(RangeCoalescingReader::try_new(
             (),
-            RangeCoalescingOptions::default().with_max_overfetch_ratio(0.9)
+            RangeCoalescingOptions::default().with_max_request_bytes(0)
         )
         .is_err());
     }

--- a/cogp-rs/src/reader.rs
+++ b/cogp-rs/src/reader.rs
@@ -228,6 +228,39 @@ impl Reader {
         out
     }
 
+    /// Build a sync reader with Row Group and Page-level bbox pruning.
+    ///
+    /// PageIndexes are fetched lazily for the four covering bbox leaves of the
+    /// Row Groups that survive footer-level pruning. Files without PageIndexes
+    /// fall back to reading those complete Row Groups. The result remains a
+    /// conservative candidate set, so callers must apply an exact row filter.
+    pub fn sync_batch_reader_with_bbox<R: ChunkReader + 'static>(
+        &self,
+        reader: R,
+        row_groups: &[usize],
+        bbox: [f64; 4],
+    ) -> Result<ParquetRecordBatchReader> {
+        let row_groups = self.bbox_candidate_row_groups(row_groups, bbox);
+        let selection = match self.bbox_column_indexes() {
+            Some(columns) => crate::page_index::read_sync(
+                &reader,
+                self.arrow_meta.metadata(),
+                &row_groups,
+                columns,
+                bbox,
+            )?,
+            None => None,
+        };
+        let builder =
+            ParquetRecordBatchReaderBuilder::new_with_metadata(reader, self.arrow_meta.clone())
+                .with_row_groups(row_groups);
+        let builder = match selection {
+            Some(selection) => builder.with_row_selection(selection),
+            None => builder,
+        };
+        Ok(builder.build()?)
+    }
+
     /// Build a sync [`ParquetRecordBatchReader`] against a fresh `ChunkReader`,
     /// reusing the cached footer metadata (no second footer parse).
     pub fn sync_batch_reader<R: ChunkReader + 'static>(
@@ -254,6 +287,71 @@ impl Reader {
         let builder =
             ParquetRecordBatchStreamBuilder::new_with_metadata(reader, self.arrow_meta.clone());
         Ok(builder.with_row_groups(row_groups.to_vec()).build()?)
+    }
+
+    /// Build an async stream with Row Group and Page-level bbox pruning.
+    ///
+    /// Only the bbox PageIndexes for candidate Row Groups are requested. The
+    /// reader's vectored-range implementation controls concurrency and range
+    /// coalescing. Missing indexes conservatively fall back to complete groups.
+    #[cfg(feature = "async")]
+    pub async fn async_batch_stream_with_bbox<R: AsyncFileReader + Send + 'static>(
+        &self,
+        mut reader: R,
+        row_groups: &[usize],
+        bbox: [f64; 4],
+    ) -> Result<ParquetRecordBatchStream<R>> {
+        let row_groups = self.bbox_candidate_row_groups(row_groups, bbox);
+        let selection = match self.bbox_column_indexes() {
+            Some(columns) => {
+                crate::page_index::read_async(
+                    &mut reader,
+                    self.arrow_meta.metadata(),
+                    &row_groups,
+                    columns,
+                    bbox,
+                )
+                .await?
+            }
+            None => None,
+        };
+        let builder =
+            ParquetRecordBatchStreamBuilder::new_with_metadata(reader, self.arrow_meta.clone())
+                .with_row_groups(row_groups);
+        let builder = match selection {
+            Some(selection) => builder.with_row_selection(selection),
+            None => builder,
+        };
+        Ok(builder.build()?)
+    }
+
+    fn bbox_column_indexes(&self) -> Option<[usize; 4]> {
+        let covering = self
+            .geo_meta
+            .columns
+            .get(&self.geo_meta.primary_column)?
+            .covering
+            .as_ref()?;
+        let schema = self.arrow_meta.metadata().file_metadata().schema_descr();
+        let find = |path: &[String]| {
+            let dotted = path.join(".");
+            (0..schema.num_columns()).find(|&i| schema.column(i).path().string() == dotted)
+        };
+        Some([
+            find(&covering.bbox.xmin)?,
+            find(&covering.bbox.ymin)?,
+            find(&covering.bbox.xmax)?,
+            find(&covering.bbox.ymax)?,
+        ])
+    }
+
+    fn bbox_candidate_row_groups(&self, row_groups: &[usize], bbox: [f64; 4]) -> Vec<usize> {
+        let candidates = self.row_groups_intersecting_bbox(bbox);
+        row_groups
+            .iter()
+            .copied()
+            .filter(|row_group| candidates.binary_search(row_group).is_ok())
+            .collect()
     }
 }
 
@@ -286,10 +384,42 @@ mod tests {
     use crate::meta::{
         BboxCovering, CogpMeta, Covering, GeoColumn, GeoMeta, COGP_VERSION, GEOPARQUET_VERSION,
     };
-    use arrow::datatypes::{DataType, Field, Schema};
+    use arrow::array::{ArrayRef, Float64Array, RecordBatch, StructArray};
+    use arrow::datatypes::{DataType, Field, Fields, Schema};
     use parquet::arrow::ArrowWriter;
     use parquet::file::metadata::KeyValue;
+    use parquet::file::properties::{EnabledStatistics, WriterProperties};
     use std::collections::BTreeMap;
+
+    #[cfg(feature = "async")]
+    #[derive(Clone)]
+    struct TestAsyncReader {
+        data: bytes::Bytes,
+        metadata: Arc<ParquetMetaData>,
+    }
+
+    #[cfg(feature = "async")]
+    impl AsyncFileReader for TestAsyncReader {
+        fn get_bytes(
+            &mut self,
+            range: Range<u64>,
+        ) -> futures::future::BoxFuture<'_, parquet::errors::Result<bytes::Bytes>> {
+            use futures::FutureExt;
+
+            let start = range.start as usize;
+            let end = range.end as usize;
+            futures::future::ready(Ok(self.data.slice(start..end))).boxed()
+        }
+
+        fn get_metadata<'a>(
+            &'a mut self,
+            _options: Option<&'a parquet::arrow::arrow_reader::ArrowReaderOptions>,
+        ) -> futures::future::BoxFuture<'a, parquet::errors::Result<Arc<ParquetMetaData>>> {
+            use futures::FutureExt;
+
+            futures::future::ready(Ok(self.metadata.clone())).boxed()
+        }
+    }
 
     fn level(row_group_end: i64, gsd: f64) -> Level {
         Level { row_group_end, gsd }
@@ -382,6 +512,135 @@ mod tests {
         assert_eq!(r.row_groups_up_to_gsd(500.0), 0..2);
         // target coarser than every level → empty
         assert!(r.row_groups_up_to_gsd(1e9).is_empty());
+    }
+
+    fn bbox_fixture(statistics: EnabledStatistics) -> bytes::Bytes {
+        let bbox_fields = Fields::from(vec![
+            Field::new("xmin", DataType::Float64, false),
+            Field::new("ymin", DataType::Float64, false),
+            Field::new("xmax", DataType::Float64, false),
+            Field::new("ymax", DataType::Float64, false),
+        ]);
+        let schema = Arc::new(Schema::new(vec![Field::new(
+            "bbox",
+            DataType::Struct(bbox_fields.clone()),
+            false,
+        )]));
+        let values = vec![0.0, 1.0, 10.0, 11.0, 20.0, 21.0];
+        let bbox: ArrayRef = Arc::new(
+            StructArray::try_new(
+                bbox_fields,
+                vec![
+                    Arc::new(Float64Array::from(values.clone())),
+                    Arc::new(Float64Array::from(values.clone())),
+                    Arc::new(Float64Array::from(values.clone())),
+                    Arc::new(Float64Array::from(values)),
+                ],
+                None,
+            )
+            .unwrap(),
+        );
+        let batch = RecordBatch::try_new(schema.clone(), vec![bbox]).unwrap();
+        let props = WriterProperties::builder()
+            .set_statistics_enabled(statistics)
+            .set_data_page_row_count_limit(2)
+            .set_write_batch_size(2)
+            .build();
+        let mut buf = Vec::new();
+        {
+            let mut writer = ArrowWriter::try_new(&mut buf, schema, Some(props)).unwrap();
+            let mut columns = BTreeMap::new();
+            columns.insert(
+                "geometry".to_string(),
+                GeoColumn {
+                    encoding: "WKB".into(),
+                    geometry_types: vec![],
+                    covering: Some(Covering {
+                        bbox: BboxCovering {
+                            xmin: vec!["bbox".into(), "xmin".into()],
+                            ymin: vec!["bbox".into(), "ymin".into()],
+                            xmax: vec!["bbox".into(), "xmax".into()],
+                            ymax: vec!["bbox".into(), "ymax".into()],
+                        },
+                    }),
+                    bbox: None,
+                    crs: None,
+                },
+            );
+            let geo = GeoMeta {
+                version: GEOPARQUET_VERSION.into(),
+                primary_column: "geometry".into(),
+                columns,
+            };
+            let cogp = CogpMeta {
+                version: COGP_VERSION.into(),
+                levels: vec![level(0, 1.0)],
+            };
+            writer.append_key_value_metadata(KeyValue {
+                key: GEO_METADATA_KEY.into(),
+                value: Some(serde_json::to_string(&geo).unwrap()),
+            });
+            writer.append_key_value_metadata(KeyValue {
+                key: COGP_METADATA_KEY.into(),
+                value: Some(serde_json::to_string(&cogp).unwrap()),
+            });
+            writer.write(&batch).unwrap();
+            writer.close().unwrap();
+        }
+
+        bytes::Bytes::from(buf)
+    }
+
+    #[test]
+    fn bbox_batch_reader_lazily_prunes_pages() {
+        let bytes = bbox_fixture(EnabledStatistics::Page);
+        let reader = Reader::try_new(bytes.clone()).unwrap();
+        // Construction remains footer-only; indexes are fetched by the bbox
+        // read below rather than retained for unrelated future queries.
+        assert!(reader.parquet_metadata().column_index().is_none());
+        let rows = reader
+            .sync_batch_reader_with_bbox(bytes, &[0], [9.0, 9.0, 12.0, 12.0])
+            .unwrap()
+            .map(|batch| batch.unwrap().num_rows())
+            .sum::<usize>();
+        assert_eq!(rows, 2);
+    }
+
+    #[cfg(feature = "async")]
+    #[test]
+    fn async_bbox_stream_lazily_prunes_pages() {
+        use futures::{executor::block_on, StreamExt};
+
+        let bytes = bbox_fixture(EnabledStatistics::Page);
+        let reader = Reader::try_new(bytes.clone()).unwrap();
+        let rows = block_on(async move {
+            let source = TestAsyncReader {
+                data: bytes,
+                metadata: reader.parquet_metadata().clone(),
+            };
+            let mut stream = reader
+                .async_batch_stream_with_bbox(source, &[0], [9.0, 9.0, 12.0, 12.0])
+                .await
+                .unwrap();
+            let mut rows = 0;
+            while let Some(batch) = stream.next().await {
+                rows += batch.unwrap().num_rows();
+            }
+            rows
+        });
+        assert_eq!(rows, 2);
+    }
+
+    #[test]
+    fn bbox_batch_reader_falls_back_without_page_index() {
+        let bytes = bbox_fixture(EnabledStatistics::Chunk);
+        let reader = Reader::try_new(bytes.clone()).unwrap();
+        let rows = reader
+            .sync_batch_reader_with_bbox(bytes, &[0], [9.0, 9.0, 12.0, 12.0])
+            .unwrap()
+            .map(|batch| batch.unwrap().num_rows())
+            .sum::<usize>();
+        assert_eq!(rows, 6);
     }
 
     /// Build a tiny parquet `bytes::Bytes` blob with the given KV metadata

--- a/cogp-rs/src/validate.rs
+++ b/cogp-rs/src/validate.rs
@@ -49,7 +49,7 @@ pub fn run(path: &Path) -> Result<()> {
         }
     };
     if !geo.version.starts_with("1.") {
-        warnings.push(format!("GeoParquet version is `{}`; COGP v0.1 targets 1.1.x", geo.version));
+        warnings.push(format!("GeoParquet version is `{}`; COGP v0.1.1 targets 1.1.x", geo.version));
     }
 
     let primary = geo.primary_column.clone();
@@ -196,7 +196,7 @@ pub fn run(path: &Path) -> Result<()> {
 
 fn print_report(path: &Path, errors: &[String], warnings: &[String]) {
     if errors.is_empty() {
-        println!("OK: {} conforms to COGP v0.1", path.display());
+        println!("OK: {} conforms to COGP v0.1.1", path.display());
     } else {
         println!("FAIL: {} ({} error(s))", path.display(), errors.len());
     }

--- a/cogp-rs/tests/end_to_end.rs
+++ b/cogp-rs/tests/end_to_end.rs
@@ -138,6 +138,8 @@ fn convert_args(input: &std::path::Path, output: &std::path::Path) -> ConvertArg
         webmerc_minzoom: 0,
         webmerc_maxzoom: 4,
         row_group_size: 8,
+        page_row_count: Some(2),
+        dictionary_page_size_limit: None,
         row_group_max_bytes: None,
         input_units: InputUnits::Degrees,
         geometry_column: None,
@@ -183,19 +185,28 @@ fn convert_reader_validate_pipeline() {
         prev_gsd = Some(l.gsd);
     }
     let total_rgs = reader.num_row_groups();
-    assert_eq!(cogp.levels.last().unwrap().row_group_end as usize + 1, total_rgs);
+    assert_eq!(
+        cogp.levels.last().unwrap().row_group_end as usize + 1,
+        total_rgs
+    );
 
-    // The profile relies only on row-group statistics; the converter must not
-    // add page-level index structures to the output.
-    assert!(reader
-        .parquet_metadata()
-        .row_groups()
-        .iter()
-        .all(|row_group| {
-            row_group.columns().iter().all(|column| {
-                column.column_index_offset().is_none() && column.offset_index_offset().is_none()
+    // Page layout writes offset indexes for every projected leaf, while only
+    // the four bbox leaves need Page-level min/max column indexes.
+    for row_group in reader.parquet_metadata().row_groups() {
+        assert!(row_group
+            .columns()
+            .iter()
+            .all(|column| column.offset_index_offset().is_some()));
+        let bbox_indexes = row_group
+            .columns()
+            .iter()
+            .filter(|column| {
+                column.column_path().parts().first().map(String::as_str) == Some("bbox")
+                    && column.column_index_offset().is_some()
             })
-        }));
+            .count();
+        assert_eq!(bbox_indexes, 4);
+    }
 
     // Selector contracts.
     assert!(reader.row_groups_in_level(reader.levels().len()).is_none());
@@ -280,6 +291,18 @@ fn convert_rejects_zero_thinning_factor() {
     assert!(format!("{err}").contains("point-thinning-factor"));
 }
 
+#[test]
+fn convert_rejects_zero_dictionary_page_size_limit() {
+    let tmp = TempDir::new("zerodictionarypage");
+    let input = tmp.path().join("input.parquet");
+    let output = tmp.path().join("out.parquet");
+    write_input(&input);
+    let mut args = convert_args(&input, &output);
+    args.dictionary_page_size_limit = Some(0);
+    let err = cogp::convert::run(args).unwrap_err();
+    assert!(format!("{err}").contains("dictionary-page-size-limit"));
+}
+
 /// Convert reuses an existing GeoParquet 1.1 `covering.bbox` column instead
 /// of recomputing per-feature bboxes from WKB. The reuse path also drops
 /// the original column from the output.
@@ -297,11 +320,7 @@ fn convert_reuses_existing_bbox_column() {
     ]);
     let schema = Arc::new(Schema::new(vec![
         Field::new("id", DataType::Int32, false),
-        Field::new(
-            "bbox",
-            DataType::Struct(bbox_struct_fields.clone()),
-            false,
-        ),
+        Field::new("bbox", DataType::Struct(bbox_struct_fields.clone()), false),
         Field::new("geometry", DataType::Binary, false),
     ]));
 
@@ -346,8 +365,7 @@ fn convert_reuses_existing_bbox_column() {
     let geom_arr: ArrayRef = Arc::new(BinaryArray::from(
         geoms.iter().map(|v| v.as_slice()).collect::<Vec<_>>(),
     ));
-    let batch =
-        RecordBatch::try_new(schema.clone(), vec![id_arr, bbox_arr, geom_arr]).unwrap();
+    let batch = RecordBatch::try_new(schema.clone(), vec![id_arr, bbox_arr, geom_arr]).unwrap();
 
     let mut cols = BTreeMap::new();
     cols.insert(
@@ -386,9 +404,8 @@ fn convert_reuses_existing_bbox_column() {
     cogp::convert::run(convert_args(&input, &output)).unwrap();
     cogp::validate::run(&output).unwrap();
 
-    // Output must still have exactly one `bbox` column (the writer's own) —
-    // the input one was dropped and the new one was inserted. The id column
-    // must survive intact.
+    // Output must still have exactly one `bbox` column (the writer's own), at
+    // the same top-level position and with the same logical field types.
     let reader = Reader::open(&output).unwrap();
     let rgs: Vec<usize> = (0..reader.num_row_groups()).collect();
     let f = File::open(&output).unwrap();
@@ -398,6 +415,14 @@ fn convert_reuses_existing_bbox_column() {
         .map(|b| b.unwrap())
         .collect();
     let schema = batches[0].schema();
+    assert_eq!(
+        schema
+            .fields()
+            .iter()
+            .map(|f| f.name().as_str())
+            .collect::<Vec<_>>(),
+        vec!["id", "bbox", "geometry"]
+    );
     assert!(schema.field_with_name("id").is_ok());
     assert!(schema.field_with_name("bbox").is_ok());
     assert!(schema.field_with_name("geometry").is_ok());

--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "name": "cloud-optimized-geoparquet",
+  "version": "0.1.1",
   "private": true,
   "packageManager": "pnpm@11.18.0",
   "scripts": {


### PR DESCRIPTION
## Summary

- add configurable RowGroup, data-page, and dictionary-page layout controls while preserving the input schema
- spatially pack page-sized intervals and use bbox PageIndexes in the Rust and JavaScript readers
- replace ratio-based range coalescing with bounded absolute byte budgets
- prefetch PageIndexes in bounded windows and issue bbox decode batches with concurrency four
- disable the browser HTTP cache and add a containment-aware 64 MiB in-memory Range LRU

## Validation

- pnpm --filter cogp test: 13 passed
- pnpm --filter cogp-demo build: passed
- cargo test -p cogp --all-features: 66 passed
- cargo clippy -p cogp --all-features --all-targets -- -D warnings: passed
- rustfmt check for changed Rust files: passed
- all 24 POI viewport queries retained identical row counts and ID fingerprints

## POI benchmark

Using the 65,536 RowGroup / 512-row Page / 32 KiB dictionary candidate with a 25 ms simulated RTT:

- cold request count fell by about 31-34% compared with the original reader
- elapsed query time fell by about 63-74%
- cold transfer increased by about 22-41% as the explicit tradeoff for fewer requests
- repeating the Tokyo 10 m query on the same reader issued zero HTTP requests and transferred zero bytes

## Notes

- maxOverfetchRatio is replaced by maxExtraBytes and maxRequestBytes
- raw benchmark outputs and generated Parquet files are intentionally excluded from this PR
